### PR TITLE
Add Agent Skills standard compliance and auto-discovery

### DIFF
--- a/.codex/vibes-codex
+++ b/.codex/vibes-codex
@@ -26,20 +26,35 @@ const vibesDir = resolvePluginRoot() || path.join(path.dirname(__dirname));
 const skillsDir = path.join(vibesDir, 'skills');
 const bootstrapFile = path.join(vibesDir, '.codex', 'vibes-bootstrap.md');
 
-const SKILLS = ['vibes', 'riff', 'sell', 'exe', 'connect', 'design-reference', 'cloudflare', 'test'];
-// Note: 'launch' skill excluded — requires Claude Code Agent Teams (not available in Codex/OpenCode)
-
 function extractFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return {};
   const fm = {};
   for (const line of match[1].split('\n')) {
     const idx = line.indexOf(':');
-    if (idx > 0) {
+    if (idx > 0 && !line.startsWith(' ')) {
       fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
     }
   }
   return fm;
+}
+
+// Auto-discover skills from filesystem instead of hardcoded list.
+// Excludes skills with compatibility fields mentioning "Claude Code"
+// (e.g., launch requires Agent Teams, not available in other harnesses).
+function discoverSkills() {
+  if (!fs.existsSync(skillsDir)) return [];
+  return fs.readdirSync(skillsDir)
+    .filter(name => {
+      if (name.startsWith('.')) return false;
+      const skillPath = path.join(skillsDir, name, 'SKILL.md');
+      if (!fs.existsSync(skillPath)) return false;
+      const content = fs.readFileSync(skillPath, 'utf8');
+      const fm = extractFrontmatter(content);
+      if (fm.compatibility && fm.compatibility.toLowerCase().includes('claude code')) return false;
+      return true;
+    })
+    .sort();
 }
 
 function runBootstrap() {
@@ -66,18 +81,17 @@ function runBootstrap() {
 }
 
 function runFindSkills() {
+  const skills = discoverSkills();
   console.log('Available skills:');
   console.log('==================\n');
 
-  for (const skill of SKILLS) {
+  for (const skill of skills) {
     const skillPath = path.join(skillsDir, skill, 'SKILL.md');
-    if (fs.existsSync(skillPath)) {
-      const content = fs.readFileSync(skillPath, 'utf8');
-      const fm = extractFrontmatter(content);
-      console.log(`- vibes:${skill}`);
-      if (fm.description) console.log(`  ${fm.description}`);
-      console.log('');
-    }
+    const content = fs.readFileSync(skillPath, 'utf8');
+    const fm = extractFrontmatter(content);
+    console.log(`- vibes:${skill}`);
+    if (fm.description) console.log(`  ${fm.description}`);
+    console.log('');
   }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,12 +205,13 @@ This plugin works with multiple coding agents, not just Claude Code.
 
 | File | What to Update |
 |------|----------------|
-| `.codex/vibes-codex` | `SKILLS` array (line ~45) |
 | `.codex/vibes-bootstrap.md` | Skills table |
 | `README.md` | Skills section |
 | `commands/` | Add a command `.md` if the skill should be user-invocable |
 
-**Claude Code-only skills** (e.g., `launch` — requires Agent Teams) are excluded from `.codex/vibes-codex` and `.codex/vibes-bootstrap.md`. Add a note pointing Codex/OpenCode users to the sequential alternative.
+**Note:** `.codex/vibes-codex` auto-discovers skills from the filesystem — no manual update needed. It excludes skills whose `compatibility` frontmatter field mentions "Claude Code" (e.g., `launch` requires Agent Teams).
+
+**Claude Code-only skills** need `compatibility: Requires Claude Code with Agent Teams support` (or similar) in their SKILL.md frontmatter. The `.codex/` system auto-excludes them. Add a note in `.codex/vibes-bootstrap.md` pointing Codex/OpenCode users to the sequential alternative.
 
 **Skill content changes** (editing `skills/*/SKILL.md`) flow automatically to all harnesses—no manual steps needed.
 

--- a/docs/cross-harness.md
+++ b/docs/cross-harness.md
@@ -1,0 +1,107 @@
+# Cross-Harness Architecture
+
+Vibes skills conform to the [Agent Skills standard](https://agentskills.io). Each skill is a directory under `skills/` with a `SKILL.md` file containing YAML frontmatter (name, description, license, allowed-tools, metadata) and Markdown instructions. This document covers what the standard provides, where it stops, and how Vibes bridges the gaps.
+
+## Agent Skills Standard Compliance
+
+| Spec Requirement | Status |
+|---|---|
+| SKILL.md with YAML frontmatter | Compliant (9 skills) |
+| `name` matches parent directory | Compliant |
+| `description` < 1024 chars | Compliant |
+| Progressive disclosure (frontmatter at startup, body on activation) | Compliant |
+| Line count < 500 (recommended) | 6/9 comply; vibes (607), sell (779), test (719) exceed due to multi-phase workflows |
+
+## What the Standard Covers
+
+- **SKILL.md format**: YAML frontmatter schema with `name`, `description`, `license`, `allowed-tools`, `metadata`
+- **Directory structure**: conventions for `scripts/`, `references/`, `assets/` subdirectories
+- **Progressive disclosure**: agents read frontmatter at startup for skill selection, load the full body only on activation
+- **`allowed-tools`**: pre-approved tool declarations so agents can grant permissions before execution
+
+## What We Add: The `.codex/` System
+
+The Agent Skills standard defines the skill format but not:
+- How agents discover skills across install locations
+- How to translate tool names between agents
+- How to detect project state and recommend skills
+
+The `.codex/` directory solves these last-mile problems.
+
+### vibes-codex CLI
+
+File: `.codex/vibes-codex`
+
+A 4-command router for non-Claude-Code agents:
+
+| Command | Purpose |
+|---|---|
+| `bootstrap` | Inject context: tool mappings, skill list, critical rules |
+| `use-skill <name>` | Load a skill's SKILL.md (strips frontmatter, outputs body) |
+| `run <script> [args]` | Execute a vibes script with `VIBES_PLUGIN_ROOT` set |
+| `find-skills` | List available skills with descriptions from frontmatter |
+
+### vibes-bootstrap.md
+
+File: `.codex/vibes-bootstrap.md`
+
+Tool mapping table that translates Claude Code tool names to generic equivalents:
+
+| Claude Code Tool | Generic Equivalent |
+|---|---|
+| `AskUserQuestion` | Prompt user directly |
+| `Skill` tool | `vibes-codex use-skill` command |
+| `Task` tool (subagents) | Spawn parallel agents if available; otherwise sequential |
+| `Read`, `Write`, `Edit`, `Bash` | Use native equivalents |
+| `${CLAUDE_PLUGIN_ROOT}` | `~/.vibes` |
+
+### INSTALL.md
+
+File: `.codex/INSTALL.md`
+
+Fetchable installation guide: clone to `~/.vibes`, install deps, add a config block to the agent's system prompt that triggers `vibes-codex bootstrap` on startup.
+
+### resolve-paths.js
+
+File: `lib/resolve-paths.js`
+
+Canonical path resolution that finds the plugin directory across four install locations (checked in order):
+
+1. `VIBES_PLUGIN_ROOT` environment variable
+2. Claude Code plugin cache (`~/.claude/plugins/cache/vibes-cli/vibes/<version>`)
+3. Standard git clone (`~/.vibes`)
+4. Development mode (relative to script location)
+
+## Three-Tier Distribution Model
+
+| Tier | Agent | Discovery | Context Injection |
+|---|---|---|---|
+| Native | Claude Code | Marketplace install | SessionStart hook via `hooks/hooks.json` (automatic) |
+| CLI | Codex, OpenCode | `git clone` + config | `vibes-codex bootstrap` (manual trigger) |
+| Manual | Cursor, Gemini, others | `git clone` | Read `skills/` directory directly |
+
+**Native tier** uses a SessionStart hook (`hooks/session-start.sh`) that fires on startup, resume, clear, and compact events. It reads `hooks/session-context.md` for static skill-awareness context, then detects project state (`.env` presence, Clerk keys, `app.jsx`, `index.html`) and appends dynamic hints.
+
+**CLI tier** relies on the agent's config to trigger `vibes-codex bootstrap` at session start. The bootstrap command outputs the same skill-awareness context plus a tool mapping table.
+
+**Manual tier** works with any agent that can read files. Point the agent at `skills/` and let it read SKILL.md files directly.
+
+## Adding Vibes Skills to Other Agents
+
+For any agent that supports the Agent Skills standard:
+
+1. Clone: `git clone https://github.com/popmechanic/vibes-cli.git ~/.vibes`
+2. Install deps: `cd ~/.vibes/scripts && npm install`
+3. Point your agent's skill search path at `~/.vibes/skills/`
+
+For agents without native skill support, add the bootstrap block to your agent's config (see `.codex/INSTALL.md` for the exact snippet).
+
+## Agent-Specific Skill: `launch`
+
+The `launch` skill (`skills/launch/SKILL.md`) requires Claude Code Agent Teams (`Task`, `Teammate`, `SendMessage` tools). Its frontmatter declares this via a `compatibility` field:
+
+```yaml
+compatibility: Requires Claude Code with Agent Teams support
+```
+
+The `.codex/vibes-codex` CLI auto-discovers skills from the filesystem and excludes any skill whose `compatibility` field mentions "Claude Code". The bootstrap context directs non-Claude-Code agents to the sequential alternative: run `vibes`, `sell`, `connect`, and `cloudflare` skills one after another.

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -3,6 +3,9 @@ name: cloudflare
 description: Self-contained deploy automation — invoke directly, do not decompose. Deploys a Vibes app to Cloudflare Workers with subdomain registry. Uses KV for storage and native Web Crypto for JWT verification.
 license: MIT
 allowed-tools: Bash, Read, Glob, AskUserQuestion, Write
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:cloudflare". Do not decompose the steps below into separate plan tasks.

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -3,6 +3,9 @@ name: connect
 description: Self-contained deploy automation — invoke directly, do not decompose. Deploys Fireproof Connect to a dedicated Studio VM on exe.dev. Sets up cloud sync backend for all your Vibes apps.
 license: MIT
 allowed-tools: Bash, Read, Glob, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:connect". Do not decompose the steps below into separate plan tasks.

--- a/skills/design-reference/SKILL.md
+++ b/skills/design-reference/SKILL.md
@@ -3,6 +3,9 @@ name: design-reference
 description: Self-contained design transformer — invoke directly, do not decompose. Transforms a design reference HTML file into a Vibes app. Use when user provides a design.html, mockup, or static prototype to match exactly.
 license: MIT
 allowed-tools: Read, Write, Bash, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:design-reference". Do not decompose the steps below into separate plan tasks.

--- a/skills/exe/SKILL.md
+++ b/skills/exe/SKILL.md
@@ -3,6 +3,9 @@ name: exe
 description: Self-contained deploy automation — invoke directly, do not decompose. Deploys a Vibes app to exe.dev VM hosting. Uses nginx on persistent VMs with SSH automation. Supports client-side multi-tenancy via subdomain-based Fireproof database isolation.
 license: MIT
 allowed-tools: Bash, Read, Glob, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:exe". Do not decompose the steps below into separate plan tasks.

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -5,6 +5,10 @@ description: Self-contained SaaS pipeline — invoke directly, do not decompose.
   to parallelize for maximum speed.
 license: MIT
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, Task, Teammate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
+compatibility: Requires Claude Code with Agent Teams support
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:launch". Do not decompose the steps below into separate plan tasks.

--- a/skills/riff/SKILL.md
+++ b/skills/riff/SKILL.md
@@ -3,6 +3,9 @@ name: riff
 description: Self-contained parallel generator — invoke directly, do not decompose. Generates 3-10 app variations in parallel for comparing ideas. Use when user says "explore options", "give me variations", "riff on this", "brainstorm approaches", or wants to see multiple interpretations of a concept.
 license: MIT
 allowed-tools: Read, Write, Bash, Task, Glob, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:riff". Do not decompose the steps below into separate plan tasks.

--- a/skills/sell/SKILL.md
+++ b/skills/sell/SKILL.md
@@ -3,6 +3,9 @@ name: sell
 description: Self-contained SaaS automation — invoke directly, do not decompose. Transforms a Vibes app into a multi-tenant SaaS with subdomain-based tenancy. Adds Clerk authentication, subscription gating, and generates a unified app with landing page, tenant routing, and admin dashboard.
 license: MIT
 allowed-tools: Read, Write, Bash, Glob, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:sell". Do not decompose the steps below into separate plan tasks.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -3,6 +3,9 @@ name: test
 description: Self-contained test automation — invoke directly, do not decompose. End-to-end integration test that assembles a fixture, deploys Connect + Cloudflare, and presents a live URL for browser verification.
 license: MIT
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:test". Do not decompose the steps below into separate plan tasks.

--- a/skills/vibes/SKILL.md
+++ b/skills/vibes/SKILL.md
@@ -3,6 +3,9 @@ name: vibes
 description: Self-contained app generator — invoke this skill directly, do not decompose into sub-steps. Generates React web apps with Fireproof database. Use when creating new web applications, adding components, or working with local-first databases. Ideal for quick prototypes and single-page apps that need real-time data sync.
 license: MIT
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
+metadata:
+  author: "Marcus Estes"
+  version: "0.1.63"
 ---
 
 > **Plan mode**: If you are planning work, this entire skill is ONE plan step: "Invoke /vibes:vibes". Do not decompose the steps below into separate plan tasks.


### PR DESCRIPTION
## Summary
- Add `metadata` (author, version) and `compatibility` fields to all 9 SKILL.md files per the [Agent Skills standard](https://agentskills.io/specification)
- Replace hardcoded skills list in `.codex/vibes-codex` with filesystem auto-discovery that reads `compatibility` frontmatter to exclude Claude Code-only skills
- Add `docs/cross-harness.md` documenting the three-tier distribution model and what Vibes builds beyond the standard

## Test plan
- [x] `VIBES_PLUGIN_ROOT=. node .codex/vibes-codex find-skills` lists 8 skills, excludes `launch`
- [x] All 433 script tests pass (`cd scripts && npm test`)
- [x] `launch` SKILL.md has `compatibility: Requires Claude Code with Agent Teams support`
- [x] All 9 skills have `metadata` with author and version

🤖 Generated with [Claude Code](https://claude.com/claude-code)