### PR TITLE
Add PNG preview thumbnails for all themes

### DIFF
--- a/scripts/server/router.ts
+++ b/scripts/server/router.ts
@@ -224,6 +224,28 @@ function serveThemes(ctx: ServerContext): Response {
   return json(result);
 }
 
+async function serveThemePreview(ctx: ServerContext, url: URL): Promise<Response> {
+  const id = (url.searchParams.get('id') || '').replace(/[^a-z0-9-]/gi, '');
+  if (!id) return new Response('Missing id', { status: 400, headers: corsHeaders() });
+  const imgPath = join(ctx.themeDir, `${id}.png`);
+  const file = Bun.file(imgPath);
+  if (!(await file.exists())) return new Response('No preview', { status: 404, headers: corsHeaders() });
+  return new Response(file, { headers: { 'Content-Type': 'image/png', 'Cache-Control': 'no-cache', ...corsHeaders() } });
+}
+
+async function saveThemePreview(ctx: ServerContext, req: Request, url: URL): Promise<Response> {
+  const id = (url.searchParams.get('id') || '').replace(/[^a-z0-9-]/gi, '');
+  if (!id) return new Response('Missing id', { status: 400, headers: corsHeaders() });
+  try {
+    const body = await readBodyWithLimit(req, MAX_SCREENSHOT_SIZE);
+    writeFileSync(join(ctx.themeDir, `${id}.png`), body);
+    return json({ ok: true });
+  } catch (err: any) {
+    if (err.status === 413) return json({ error: 'Preview too large (max 5MB)' }, 413);
+    return json({ error: err.message }, 400);
+  }
+}
+
 function serveHasKey(ctx: ServerContext): Response {
   return json({ hasKey: !!ctx.openRouterKey });
 }
@@ -598,6 +620,8 @@ export function createRouter(ctx: ServerContext) {
       case 'GET /app.jsx':                   return serveAppJsx(ctx);
       case 'GET /themes':                    return serveThemes(ctx);
       case 'GET /themes/has-key':            return serveHasKey(ctx);
+      case 'GET /themes/preview':             return serveThemePreview(ctx, url);
+      case 'POST /themes/preview':            return saveThemePreview(ctx, req, url);
       case 'GET /animations':               return serveAnimations(ctx);
       case 'GET /skills':                    return serveSkills(ctx);
       case 'GET /app-frame':                return serveAppFrame(ctx);

--- a/skills/vibes/templates/editor.html
+++ b/skills/vibes/templates/editor.html
@@ -739,7 +739,7 @@
     /* Theme carousel */
     .theme-carousel {
       display: flex;
-      align-items: center;
+      align-items: stretch;
       gap: 10px;
       width: 100%;
     }
@@ -755,7 +755,6 @@
     }
     .theme-carousel-arrow {
       width: 28px;
-      height: 28px;
       min-width: 28px;
       display: flex;
       align-items: center;
@@ -768,6 +767,7 @@
       padding: 0;
       opacity: 0.6;
       transition: opacity 0.2s;
+      align-self: center;
     }
     .theme-carousel-arrow:hover { opacity: 1; }
     .theme-carousel-viewport {
@@ -785,21 +785,37 @@
       flex-shrink: 0;
       width: calc((100% - 8px - 2 * 12px) / 3);
       box-sizing: border-box;
-      padding: 0.5rem 0.75rem;
+      padding: 0;
       border: 2px solid var(--vibes-near-black);
       border-radius: 8px;
       background: var(--vibes-cream);
       font-family: inherit;
-      font-size: 0.8125rem;
+      cursor: pointer;
+      overflow: hidden;
+      position: relative;
+      transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+      display: flex;
+      flex-direction: column;
+    }
+    .theme-carousel-btn .theme-thumb {
+      width: 100%;
+      aspect-ratio: 16 / 10;
+      background: #333;
+      overflow: hidden;
+      position: relative;
+      border-bottom: 2px solid var(--vibes-near-black);
+      pointer-events: none;
+    }
+    .theme-carousel-btn .theme-name {
+      padding: 0.35rem 0.5rem;
+      font-size: 0.6875rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 1px;
-      cursor: pointer;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      position: relative;
-      transition: background 0.2s, transform 0.2s;
+      text-align: center;
     }
     .theme-carousel-btn::after {
       content: '';
@@ -807,7 +823,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      height: 4px;
+      height: 3px;
     }
     .theme-carousel-btn:nth-child(3n+1)::after { background: var(--vibes-blue); }
     .theme-carousel-btn:nth-child(3n+2)::after { background: var(--vibes-red); }
@@ -2037,13 +2053,25 @@
       background: var(--vibes-cream);
       border: 2px solid var(--vibes-near-black);
       border-radius: 8px;
-      padding: 0.75rem;
+      padding: 0;
       cursor: pointer;
       transition: all 0.15s;
       box-shadow: 4px 4px 0px 0px var(--vibes-blue), 4px 4px 0px 2px var(--vibes-near-black);
+      overflow: hidden;
+    }
+    .theme-card-thumb {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #333;
+      overflow: hidden;
+      pointer-events: none;
+      border-bottom: 2px solid var(--vibes-near-black);
+    }
+    .theme-card-body {
+      padding: 0.5rem 0.75rem 0.6rem;
     }
     .theme-card-delete {
-      position: absolute; top: 4px; right: 4px;
+      position: absolute; top: 4px; right: 4px; z-index: 2;
       width: 20px; height: 20px; border-radius: 50%;
       border: 1.5px solid var(--vibes-near-black);
       background: var(--vibes-cream); color: var(--vibes-near-black);
@@ -3744,14 +3772,20 @@
     }
   }
 
+  function themeThumbHtml(id, context) {
+    const cls = context === 'card' ? 'theme-card-thumb' : 'theme-thumb';
+    if (!id) return `<div class="${cls}" style="display:flex;align-items:center;justify-content:center;background:var(--vibes-near-black);color:var(--vibes-cream);font-size:1.5rem;">✦</div>`;
+    return `<div class="${cls}"><img src="/themes/preview?id=${id}" style="width:100%;height:100%;object-fit:cover;" onerror="this.parentElement.style.background='var(--vibes-near-black)';this.remove();" /></div>`;
+  }
+
   function buildThemeCarousel() {
     const track = document.getElementById('themeCarouselTrack');
     if (!track) return;
     // "Auto" + all themes
     const items = [{ id: '', name: 'Auto' }, ...themes];
-    track.innerHTML = items.map((t, i) =>
-      `<button class="theme-carousel-btn${t.id === selectedThemeId ? ' active' : ''}" data-theme-id="${t.id}" onclick="selectThemeCarousel('${t.id}')">${t.name}</button>`
-    ).join('');
+    track.innerHTML = items.map((t, i) => {
+      return `<button class="theme-carousel-btn${t.id === selectedThemeId ? ' active' : ''}" data-theme-id="${t.id}" onclick="selectThemeCarousel('${t.id}')">${themeThumbHtml(t.id, 'carousel')}<span class="theme-name">${t.name}</span></button>`;
+    }).join('');
     requestAnimationFrame(() => updateCarouselPosition());
   }
 
@@ -5293,10 +5327,13 @@
     function cardHtml(t) {
       return `<div class="theme-card${t.recommended ? ' recommended' : ''}" onclick="selectTheme('${t.id}')">
         <button class="theme-card-delete" onclick="event.stopPropagation();confirmDeleteTheme('${t.id}','${t.name.replace(/'/g, "\\'")}')" title="Delete theme">&times;</button>
-        ${swatchHtml(t.colors)}
-        <div class="theme-card-name">${t.name}${t.recommended ? '<span class="theme-card-badge">recommended</span>' : ''}</div>
-        <div class="theme-card-mood">${t.mood}</div>
-        <div class="theme-card-for">${t.bestFor}</div>
+        ${themeThumbHtml(t.id, 'card')}
+        <div class="theme-card-body">
+          ${swatchHtml(t.colors)}
+          <div class="theme-card-name">${t.name}${t.recommended ? '<span class="theme-card-badge">recommended</span>' : ''}</div>
+          <div class="theme-card-mood">${t.mood}</div>
+          <div class="theme-card-for">${t.bestFor}</div>
+        </div>
       </div>`;
     }
 
@@ -5371,7 +5408,7 @@
     } else if (badge) {
       badge.style.display = 'none';
     }
-    setTimeout(() => search.focus(), 100);
+    setTimeout(() => { search.focus(); }, 100);
   }
 
   function closeThemeModal() {
@@ -5430,7 +5467,7 @@
     if (stageEl && stage) stageEl.textContent = stage;
   }
 
-  function onThemeCreated(themeId, themeName) {
+  async function onThemeCreated(themeId, themeName) {
     document.getElementById('saveThemeBtn').disabled = false;
 
     // Set the new theme as the current active theme
@@ -5453,21 +5490,153 @@
       if (Date.now() < end) requestAnimationFrame(frame);
     })();
 
-    reloadThemes().then(() => {
-      // After reload, select the newly saved theme in carousel
-      selectThemeCarousel(themeId);
-      // Update the current theme badge in modal
-      const badge = document.getElementById('currentThemeBadge');
-      if (badge) { badge.textContent = 'Current: ' + themeName; badge.style.display = ''; }
-    });
+    // Capture preview in background (don't block UI)
+    captureThemePreview(themeId);
 
-    // Fade out toast and close modal after 2.5s
+    // Reset save mode UI back to browse
+    saveMode = false;
+    document.getElementById('saveThemeSection').style.display = 'none';
+    document.getElementById('themeSearch').style.display = '';
+    document.getElementById('themeGrid').style.display = '';
+    document.getElementById('saveThemeToggle').textContent = 'Save Theme';
+    document.getElementById('saveThemeName').value = '';
+    document.getElementById('saveThemeStatus').innerHTML = '';
+
+    // Close modal, reload themes, carousel will update
+    closeThemeModal();
+
+    await reloadThemes();
+    selectThemeCarousel(themeId);
+
+    // Fade toast
     setTimeout(() => {
       toast.style.opacity = '0';
       setTimeout(() => toast.remove(), 300);
-      closeThemeModal();
-      saveMode = false;
-    }, 2500);
+    }, 1500);
+  }
+
+  async function captureThemePreview(themeId) {
+    try {
+      // Read current theme colors from the preview iframe
+      const pf = document.getElementById('previewFrame');
+      const pdoc = pf?.contentDocument;
+      if (!pdoc) return;
+      const cs = getComputedStyle(pdoc.documentElement);
+      const v = (name) => cs.getPropertyValue(name)?.trim() || '';
+      const bg = v('--comp-bg') || '#1a1a2e';
+      const text = v('--comp-text') || '#eee';
+      const border = v('--comp-border') || '#333';
+      const accent = v('--comp-accent') || '#e94560';
+      const accentText = v('--comp-accent-text') || '#fff';
+      const muted = v('--comp-muted') || '#888';
+      const pageBg = v('--color-background') || '#0f0f23';
+
+      // Draw showcase directly to canvas — no iframes or external libs needed
+      const W = 800, H = 500;
+      const canvas = document.createElement('canvas');
+      canvas.width = W; canvas.height = H;
+      const ctx = canvas.getContext('2d');
+
+      // Helper functions
+      const roundRect = (x, y, w, h, r) => { ctx.beginPath(); ctx.roundRect(x, y, w, h, r); };
+      const fillRect = (x, y, w, h, color) => { ctx.fillStyle = color; ctx.fillRect(x, y, w, h); };
+
+      // Page background
+      fillRect(0, 0, W, H, pageBg);
+
+      // Header
+      ctx.fillStyle = text; ctx.font = 'bold 22px system-ui'; ctx.fillText('Theme Preview', 24, 40);
+      ctx.fillStyle = muted; ctx.font = '10px system-ui'; ctx.fillText('SHOWCASE', 680, 38);
+      ctx.strokeStyle = border; ctx.lineWidth = 1; ctx.beginPath(); ctx.moveTo(24, 52); ctx.lineTo(W - 24, 52); ctx.stroke();
+
+      // Card — table
+      const cardY = 66, cardH = 180;
+      roundRect(24, cardY, W - 48, cardH, 8); ctx.fillStyle = bg; ctx.fill();
+      roundRect(24, cardY, W - 48, cardH, 8); ctx.strokeStyle = border; ctx.stroke();
+
+      // Table header
+      ctx.fillStyle = muted; ctx.font = '9px system-ui';
+      const cols = ['ITEM', 'CATEGORY', 'VALUE', 'STATUS'];
+      const colX = [40, 250, 440, 580];
+      cols.forEach((c, i) => ctx.fillText(c, colX[i], cardY + 28));
+      ctx.strokeStyle = border; ctx.beginPath(); ctx.moveTo(40, cardY + 35); ctx.lineTo(W - 40, cardY + 35); ctx.stroke();
+
+      // Table rows
+      const rows = [
+        ['Alpha Module', 'Core', '92', 'Active'],
+        ['Beta System', 'Util', '85', 'Stable'],
+        ['Gamma Process', 'Data', '78', 'Pending'],
+      ];
+      rows.forEach((row, ri) => {
+        const ry = cardY + 56 + ri * 42;
+        ctx.fillStyle = text; ctx.font = '14px system-ui';
+        ctx.fillText(row[0], colX[0], ry); ctx.fillText(row[1], colX[1], ry);
+        ctx.font = 'bold 20px system-ui'; ctx.fillText(row[2], colX[2], ry + 2);
+        if (row[3] === 'Active') {
+          roundRect(colX[3], ry - 12, 60, 20, 3); ctx.fillStyle = accent; ctx.fill();
+          ctx.fillStyle = accentText; ctx.font = 'bold 11px system-ui'; ctx.fillText(row[3], colX[3] + 8, ry + 2);
+        } else {
+          ctx.fillStyle = text; ctx.font = '14px system-ui'; ctx.fillText(row[3], colX[3], ry);
+        }
+        if (ri < rows.length - 1) {
+          ctx.strokeStyle = border + '33'; ctx.beginPath(); ctx.moveTo(40, ry + 16); ctx.lineTo(W - 40, ry + 16); ctx.stroke();
+        }
+      });
+
+      // Bottom row — two cards side by side
+      const row2Y = cardY + cardH + 16, row2H = 190, gap = 16, cw = (W - 48 - gap) / 2;
+
+      // Left card — form
+      roundRect(24, row2Y, cw, row2H, 8); ctx.fillStyle = bg; ctx.fill();
+      roundRect(24, row2Y, cw, row2H, 8); ctx.strokeStyle = border; ctx.stroke();
+      ctx.fillStyle = muted; ctx.font = '9px system-ui'; ctx.fillText('SEARCH', 40, row2Y + 28);
+      roundRect(40, row2Y + 34, cw - 32, 28, 4); ctx.fillStyle = pageBg; ctx.fill();
+      roundRect(40, row2Y + 34, cw - 32, 28, 4); ctx.strokeStyle = border; ctx.stroke();
+      ctx.fillStyle = muted; ctx.font = '13px system-ui'; ctx.fillText('Filter items...', 50, row2Y + 53);
+      ctx.fillStyle = muted; ctx.font = '9px system-ui'; ctx.fillText('CATEGORY', 40, row2Y + 82);
+      roundRect(40, row2Y + 88, cw - 32, 28, 4); ctx.fillStyle = pageBg; ctx.fill();
+      roundRect(40, row2Y + 88, cw - 32, 28, 4); ctx.strokeStyle = border; ctx.stroke();
+      ctx.fillStyle = text; ctx.font = '13px system-ui'; ctx.fillText('All', 50, row2Y + 107);
+      // Buttons
+      roundRect(40, row2Y + 132, 80, 32, 4); ctx.fillStyle = accent; ctx.fill();
+      ctx.fillStyle = accentText; ctx.font = 'bold 11px system-ui'; ctx.fillText('APPLY', 56, row2Y + 152);
+      roundRect(130, row2Y + 132, 80, 32, 4); ctx.strokeStyle = border; ctx.stroke();
+      ctx.fillStyle = text; ctx.font = 'bold 11px system-ui'; ctx.fillText('RESET', 146, row2Y + 152);
+
+      // Right card — controls
+      const rcX = 24 + cw + gap;
+      roundRect(rcX, row2Y, cw, row2H, 8); ctx.fillStyle = bg; ctx.fill();
+      roundRect(rcX, row2Y, cw, row2H, 8); ctx.strokeStyle = border; ctx.stroke();
+      const ctrlItems = [
+        { label: 'Show details', checked: true },
+        { label: 'Include archived', checked: false },
+      ];
+      ctrlItems.forEach((item, i) => {
+        const cy = row2Y + 28 + i * 32;
+        roundRect(rcX + 16, cy, 16, 16, 3);
+        if (item.checked) { ctx.fillStyle = accent; ctx.fill(); ctx.fillStyle = accentText; ctx.font = 'bold 12px system-ui'; ctx.fillText('✓', rcX + 19, cy + 13); }
+        else { ctx.strokeStyle = border; ctx.stroke(); }
+        ctx.fillStyle = text; ctx.font = '13px system-ui'; ctx.fillText(item.label, rcX + 40, cy + 13);
+      });
+      // Toggles
+      const toggleItems = [{ label: 'Live updates', on: true }, { label: 'Compact view', on: false }];
+      toggleItems.forEach((item, i) => {
+        const ty = row2Y + 100 + i * 32;
+        roundRect(rcX + 16, ty, 36, 18, 9);
+        ctx.fillStyle = item.on ? accent : border; ctx.fill();
+        ctx.beginPath(); ctx.arc(item.on ? rcX + 40 : rcX + 28, ty + 9, 6, 0, Math.PI * 2);
+        ctx.fillStyle = item.on ? accentText : text; ctx.fill();
+        ctx.fillStyle = text; ctx.font = '13px system-ui'; ctx.fillText(item.label, rcX + 60, ty + 14);
+      });
+
+      // Convert to blob and upload
+      const blob = await new Promise(r => canvas.toBlob(r, 'image/png'));
+      if (!blob || blob.size < 100) return;
+      await fetch('/themes/preview?id=' + encodeURIComponent(themeId), { method: 'POST', body: blob });
+      console.log('[ThemePreview] Saved preview for', themeId);
+    } catch (err) {
+      console.warn('[ThemePreview] Failed:', err);
+    }
   }
 
   async function reloadThemes() {

--- a/skills/vibes/themes/aether.png
+++ b/skills/vibes/themes/aether.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79b6017ad17835610b1c7d3ab7b5eb338b857867856a97bf8d0cd1eb8a307944
+size 509376

--- a/skills/vibes/themes/archive.png
+++ b/skills/vibes/themes/archive.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35e6f079b2f6b36a301cd3526272fcab837c879fd45ed59848844f26622b4513
+size 39823

--- a/skills/vibes/themes/atelier.png
+++ b/skills/vibes/themes/atelier.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a800030d94fea6129029cfa1508f369bfff140d41829150a92d1053f6b194fd0
+size 163681

--- a/skills/vibes/themes/atlas.png
+++ b/skills/vibes/themes/atlas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38358cc356e5140c34c6fb409816d8b439609aa333e773ebc9e55a7abe0b22b3
+size 38028

--- a/skills/vibes/themes/broadsheet.png
+++ b/skills/vibes/themes/broadsheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a44e1bc089ba59aa3542cb1b82033e950157a5eab8b6f9dd980fc6f55b2a1134
+size 43734

--- a/skills/vibes/themes/capsule.png
+++ b/skills/vibes/themes/capsule.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6daf9f3b64f676f6a6fe903f881f2c5f535578b012f7d4be92285f02d1b8ec
+size 24285

--- a/skills/vibes/themes/carbon.png
+++ b/skills/vibes/themes/carbon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d4afc786e33c6dbda7ce9ce93c4cfb3cbfecd687e0511790527c135bc0f4856
+size 48663

--- a/skills/vibes/themes/chrome.png
+++ b/skills/vibes/themes/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01c0a4110dc9ce632e9c2e5801d99ec42626132f5110f67db233363d45d5b8de
+size 93403

--- a/skills/vibes/themes/chrono.png
+++ b/skills/vibes/themes/chrono.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c245dec48a800c944b63958d4f27eecf277d393baf734a1ab6ef663c08d560e2
+size 43355

--- a/skills/vibes/themes/codex.png
+++ b/skills/vibes/themes/codex.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f04ff3f45c16704e1f4e45fd99e30a378bfd54e8e614c0e1e1f5ce48acda8907
+size 270386

--- a/skills/vibes/themes/computer-angel-heaven.png
+++ b/skills/vibes/themes/computer-angel-heaven.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e49b05e43eca6ad002f4a7564e0c309bc88d4eae36bef5033eff8f6d92f2cfd9
+size 89550

--- a/skills/vibes/themes/console.png
+++ b/skills/vibes/themes/console.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0141290eac24760cadab60552811f88442ac73dc83231189f58ca8beae39e9e1
+size 51603

--- a/skills/vibes/themes/default.png
+++ b/skills/vibes/themes/default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:565bd9d6d08cc2f7616d47021aa443bd6beb68aef89d2d5fa3972a2859facef2
+size 66865

--- a/skills/vibes/themes/desktop.png
+++ b/skills/vibes/themes/desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c124ed43a035ef7b3ca48a981ae6274b735787dbf1a74d1d268464087af5290
+size 79962

--- a/skills/vibes/themes/dial.png
+++ b/skills/vibes/themes/dial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c3e54c9aa85c427d4c08b51221fb57da077e0beee4829f1f0815d82b66ec40b
+size 77853

--- a/skills/vibes/themes/dossier.png
+++ b/skills/vibes/themes/dossier.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ac1f4e615617cd2901b6716556bafe4f75796f7fe5f8f4ed920c211c005ecf9
+size 34219

--- a/skills/vibes/themes/edge.png
+++ b/skills/vibes/themes/edge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29aad2ee15a1cfd4b4368285792e156ef7d8cfe5d648f0a5114b1638c91ede2f
+size 150077

--- a/skills/vibes/themes/guild.png
+++ b/skills/vibes/themes/guild.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:485907387a2208da5fb3c32e76acd831c0eae43318d6016728e6f3a0305a3941
+size 552760

--- a/skills/vibes/themes/hearth.png
+++ b/skills/vibes/themes/hearth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f076e9846dc6ab6f9ebaac0503b2e2511d9029137e6a22f7fa7d863f1bc0384b
+size 185605

--- a/skills/vibes/themes/industrial.png
+++ b/skills/vibes/themes/industrial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75c4df437039ab8372cda75d72d104e8fb733c0a4297bcdd44bdf3e1fe15a801
+size 31535

--- a/skills/vibes/themes/matrix.png
+++ b/skills/vibes/themes/matrix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:208e2b66da603410982ddb0f79ad35c0a1980995dba0cf4f31f7aaa5b9888978
+size 56191

--- a/skills/vibes/themes/mesh.png
+++ b/skills/vibes/themes/mesh.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b4c7397a8ce3d29d8625d425569f68040a261025a317088e0da94c075ee7739
+size 35439

--- a/skills/vibes/themes/neon.png
+++ b/skills/vibes/themes/neon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55c3bd28140f08993c5fc76b32510bfa72975b4cf1705e0f71625a98d3d0e74e
+size 107888

--- a/skills/vibes/themes/nexus.png
+++ b/skills/vibes/themes/nexus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68ff9486e709311bbc5942f075f2e131fa37297f1e3db66db312b197c7010faf
+size 18170

--- a/skills/vibes/themes/opus.png
+++ b/skills/vibes/themes/opus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b63da9cb92a7e8e151df51c6cb391f78381aebd52b2cc25c248c8aeea97dc2b2
+size 43067

--- a/skills/vibes/themes/orbit.png
+++ b/skills/vibes/themes/orbit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4752e2fa8c1fadfee809f51f8daba5f0a53f5d227346c9809936900480fb94b4
+size 108552

--- a/skills/vibes/themes/palate.png
+++ b/skills/vibes/themes/palate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84d5b1cdc75b62c812a1204da27d9204e0468ddcd67bc2d564bf6fe4f8acaafd
+size 23192

--- a/skills/vibes/themes/pitch.png
+++ b/skills/vibes/themes/pitch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9db44ff26dac06334ccb880f2d002f916f88cfa86f7cb3e6c5910b9f6cbe488
+size 31147

--- a/skills/vibes/themes/poster.png
+++ b/skills/vibes/themes/poster.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac89680b0fa10bec587506935d4c8fc8349c6e921d326b546fb6ca0047f5c844
+size 126843

--- a/skills/vibes/themes/proof.png
+++ b/skills/vibes/themes/proof.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62860db06b3339e4eea9791f716b072535fd9f324cccac779336f09de643096a
+size 37655

--- a/skills/vibes/themes/recon.png
+++ b/skills/vibes/themes/recon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d096d396545f5e5628e75f0a217a53d7e37b5f6e1d2e6bfb7b32629181b6b57
+size 39478

--- a/skills/vibes/themes/rift.png
+++ b/skills/vibes/themes/rift.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b51f321f6f9c095b8f57477ea4c6b78ee98f6fd494d673f88c6613cc60feb517
+size 100778

--- a/skills/vibes/themes/rune.png
+++ b/skills/vibes/themes/rune.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a8c4488a6b6d9978ca9254eafb071831ceefdf6ce2a8b1387f4f8bbf5b1d4eb
+size 171808

--- a/skills/vibes/themes/scrapbook.png
+++ b/skills/vibes/themes/scrapbook.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff158735db20c6f3a14b23d60747f5dc5aef04da2447bf10645fcaef6f16d731
+size 62812

--- a/skills/vibes/themes/sensor.png
+++ b/skills/vibes/themes/sensor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ff96e09e333a218de2ea7d9c99f9664d81a4c5929ca00019dd99a3d7b60b7a2
+size 40925

--- a/skills/vibes/themes/signal.png
+++ b/skills/vibes/themes/signal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f95237f3e8f9e5cc6172ed36270c5bd07db88867f0147bde57ba03ee352f03
+size 22805

--- a/skills/vibes/themes/slab.png
+++ b/skills/vibes/themes/slab.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114a4ab874194874acaae6ca966cb6d8f1e150c8492449f077a7b51520981ac6
+size 66054

--- a/skills/vibes/themes/specimen.png
+++ b/skills/vibes/themes/specimen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea7bd5a23df68e1c6fe43fd9a6e47645af994e9b2dd1baeb49be37bd2f27a25b
+size 20435

--- a/skills/vibes/themes/sticker-cozy.png
+++ b/skills/vibes/themes/sticker-cozy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47e6010f98eb3641ff81f51453a187001badf9d0268b331f1f35e3890eb592c9
+size 44947

--- a/skills/vibes/themes/terminal.png
+++ b/skills/vibes/themes/terminal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff503854f8d189f463907b94f0ddd7345acf95ef8c7edb2188f72472cc20707c
+size 42524

--- a/skills/vibes/themes/vault.png
+++ b/skills/vibes/themes/vault.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9850674a71f3d1617c6bf727ca52af8abf3da36782d7acbe447c8831d50e9df5
+size 72623

--- a/skills/vibes/themes/water.png
+++ b/skills/vibes/themes/water.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c452e6557653aafabfd75b5e7842bcefce5e38fa9300ea2b88d2a1be3fdccf6
+size 55390

--- a/skills/vibes/themes/winter-sports.png
+++ b/skills/vibes/themes/winter-sports.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a524d2f3e0bcddc8bcc05c8f4daf2b5369fcae96ea9197c5fc7fc5b707b635
+size 37588

--- a/skills/vibes/themes/zine.png
+++ b/skills/vibes/themes/zine.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff64b78e9f44b8defecad747d3df7c2548b86969e425380a64cd453535912f8
+size 37844


### PR DESCRIPTION
## Summary
- Add PNG preview thumbnails for all 43 themes in `skills/vibes/themes/`
- Add theme preview route to server router for serving previews
- Update editor template to display theme thumbnails in the theme picker UI

## Test plan
- [ ] Verify theme PNGs render in the editor's theme picker
- [ ] Confirm theme switching still works after selecting a preview
- [ ] Check that new server route serves preview images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)