### PR TITLE
fix(factory): forward vibes_token cookie on subscribe fetch

### DIFF
--- a/skills/factory/templates/unified.html
+++ b/skills/factory/templates/unified.html
@@ -4898,7 +4898,16 @@ if (typeof window !== 'undefined') {
             const endpoint = factoryBase.replace(/\/$/, '') +
               '/checkout/' + encodeURIComponent(APP_NAME) +
               (ref ? '?ref=' + encodeURIComponent(ref) : '');
-            const res = await fetch(endpoint, { method: 'POST' });
+            // credentials: "include" forwards the shared .vibesos.com
+            // vibes_token cookie to factory.vibesos.com so the checkout
+            // handler can attribute the subscription to the signed-in
+            // user via Stripe's client_reference_id. Safe to send
+            // unauthenticated (cookie simply absent) — factory falls
+            // back to the anonymous-checkout + email-match path.
+            const res = await fetch(endpoint, {
+              method: 'POST',
+              credentials: 'include',
+            });
             if (!res.ok) {
               const body = await res.text().catch(() => '');
               throw new Error('Checkout session failed (' + res.status + '): ' + body.slice(0, 120));


### PR DESCRIPTION
## Summary

Landing-page Subscribe button now passes \`credentials: "include"\` on its \`POST /checkout/:appName\` fetch. Needed so the shared \`.vibesos.com\` \`vibes_token\` cookie reaches factory.vibesos.com from a tenant subdomain — unlocks user-id attribution on subscriptions.

Behaviour change is additive:
- Signed-in tenant visitors: cookie goes across, factory pulls userId, Stripe checkout session gets \`client_reference_id\`, webhook writes \`user:\${userId}:subscriptions\` KV index.
- Anonymous visitors: cookie simply absent, factory falls through to today's anonymous checkout + email-match path.

## Pairs with

vibes-infra PR landing: CORS \`Access-Control-Allow-Credentials: true\`, \`POST /checkout/:appName\` reads the cookie + passes \`client_reference_id\` to Stripe, \`checkout.session.completed\` webhook populates the reverse index, Home + Subscriptions read index-first.

## Deploy order

1. vibes-infra factory worker (accepts cookie, no-ops if absent)
2. This PR merged + tenant apps redeployed — phase6-launch today, any future tenants going forward.

## Test plan

- [ ] Before merge: local diff review of the ~10-line change
- [ ] After merge + redeploy: load phase6-launch.vibesos.com signed-in, click Subscribe, observe factory tail log receives the token header and writes the KV index entry
- [ ] Anonymous flow still works — incognito window, Subscribe, Stripe checkout loads

## What this does NOT do

- Does not touch tenant app code paths other than the one fetch call
- Does not change the \`/resolve\`, \`/claim\`, \`/join\` or other registry fetches — those don't need credentials