### PR TITLE
fix(assembler): substitute __FACTORY_MODE__/__FACTORY_BASE__ on non-factory paths

### DIFF
--- a/scripts/assemble-all.js
+++ b/scripts/assemble-all.js
@@ -54,6 +54,11 @@ const results = await Promise.all(
       output = output.replaceAll('__OIDC_CLIENT_ID__', OIDC_CLIENT_ID);
       output = output.replaceAll('__DEPLOY_API_URL__', DEPLOY_API_URL);
       output = output.replaceAll('__AI_PROXY_URL__', AI_PROXY_URL);
+      // Non-factory riffs still carry factoryMode/factoryBase keys in
+      // __APP_CONFIG__. Substitute with safe defaults so the raw
+      // __FACTORY_MODE__ identifier doesn't blow up at runtime.
+      output = output.replaceAll('__FACTORY_MODE__', 'false');
+      output = output.replaceAll('__FACTORY_BASE__', '');
       writeFileSync(outputPath, output);
       return { dir, success: true };
     } catch (e) {

--- a/scripts/assemble.js
+++ b/scripts/assemble.js
@@ -68,6 +68,12 @@ async function main() {
   output = output.replaceAll('__OIDC_CLIENT_ID__', OIDC_CLIENT_ID);
   output = output.replaceAll('__DEPLOY_API_URL__', DEPLOY_API_URL);
   output = output.replaceAll('__AI_PROXY_URL__', AI_PROXY_URL);
+  // Non-factory apps have no meaningful factoryMode/factoryBase but the
+  // base template still declares those keys in __APP_CONFIG__. If we don't
+  // substitute, the raw __FACTORY_MODE__ identifier evaluates as undefined
+  // at runtime and crashes the app before mount.
+  output = output.replaceAll('__FACTORY_MODE__', 'false');
+  output = output.replaceAll('__FACTORY_BASE__', '');
 
   // Inject auth gate for private apps
   if (privateMode && output.includes(AUTH_INJECT_MARKER)) {

--- a/scripts/lib/env-utils.js
+++ b/scripts/lib/env-utils.js
@@ -17,6 +17,13 @@ export const APP_CONFIG_PLACEHOLDERS = {
   '__APP_NAME__': 'preview-app',
   '__WS_URL__': '__WS_URL__',       // left as placeholder = sync skipped (template checks startsWith('__'))
   '__APP_PUBLIC__': 'true',          // preview runs as public (no auth gate)
+  // Factory-mode fields — only the factory assembler sets these to real
+  // values. In preview mode and for non-factory deploys they need safe
+  // defaults; otherwise the template's `factoryMode: __FACTORY_MODE__,`
+  // line evaluates as a reference to an undefined identifier and crashes
+  // the preview with a ReferenceError.
+  '__FACTORY_MODE__': 'false',       // literal `false` — no quotes in the template
+  '__FACTORY_BASE__': '',            // empty string — factoryBase only meaningful in factory-mode apps
 };
 
 


### PR DESCRIPTION
## Summary

Fixes a black-screen-on-preview bug for freshly-generated vibes/riff apps. The base \`__APP_CONFIG__\` block in the template declares:

\`\`\`
factoryMode: __FACTORY_MODE__,
factoryBase: \"__FACTORY_BASE__\"
\`\`\`

The factory assembler substitutes both at assembly time. The plain vibes CLI assembler (\`assemble.js\`), the batch assembler (\`assemble-all.js\`), and — crucially — the editor's live-preview server (\`scripts/server/handlers/generate.ts\`) were leaving \`__FACTORY_MODE__\` as a raw identifier. The browser evaluated it as a reference to an undefined global, threw a \`ReferenceError\`, and React never mounted. Visible as a black preview pane at \`:3333/app-frame?app=...\`.

## Change

- \`scripts/lib/env-utils.js\` — add \`__FACTORY_MODE__\` (default \`'false'\`) and \`__FACTORY_BASE__\` (default \`''\`) to \`APP_CONFIG_PLACEHOLDERS\`. The preview server already iterates that map via \`populateConnectConfig\` and picks up the fix automatically.
- \`scripts/assemble.js\` + \`scripts/assemble-all.js\` — matching \`replaceAll\` substitutions so CLI-produced HTML keeps rendering the same way post-deploy.

## No factory regression

\`assemble-factory.js\` substitutes \`__FACTORY_MODE__\` with the computed \`'true'\`/\`'false'\` BEFORE calling \`populateConnectConfig\`, so by the time my new default kicks in there's nothing left to replace. The default is only ever applied for non-factory paths.

## Test plan

- [x] \`bunx vitest run\` — 710/710 pass in \`scripts/\`.
- [x] Smoke test:
  \`\`\`js
  populateConnectConfig('factoryMode: __FACTORY_MODE__, factoryBase: \"__FACTORY_BASE__\"', {})
  // → 'factoryMode: false, factoryBase: \"\"'
  \`\`\`
  No raw placeholders remain.
- [ ] Post-merge: desktop app rebuilds, \`/vibes:vibes\` generates an app, preview panel renders without ReferenceError.

## Paired with

Nothing upstream of this — orthogonal to [#59](https://github.com/popmechanic/VibesOS/pull/59). Can merge either one independently.