### PR TITLE
fix(factory): PricingSection accepts both string and {title,description} feature shapes

### DIFF
--- a/skills/factory/templates/unified.html
+++ b/skills/factory/templates/unified.html
@@ -4783,7 +4783,7 @@ if (typeof window !== 'undefined') {
 
         .landing-page .features-list li {
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             gap: 0.75rem;
             padding: 0.75rem 0;
             font-size: 1.1rem;
@@ -4799,11 +4799,29 @@ if (typeof window !== 'undefined') {
             flex-shrink: 0;
             width: 20px;
             height: 20px;
+            margin-top: 0.25em;
             background: var(--color-foreground, #111111);
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
+        }
+
+        .landing-page .feature-text {
+            display: flex;
+            flex-direction: column;
+            gap: 0.125rem;
+        }
+
+        .landing-page .feature-title {
+            font-weight: 600;
+            line-height: 1.35;
+        }
+
+        .landing-page .feature-desc {
+            font-size: 0.9rem;
+            color: color-mix(in srgb, var(--color-foreground, #111111) 65%, transparent);
+            line-height: 1.4;
         }
 
         .landing-page .pricing-cta {
@@ -4847,16 +4865,34 @@ if (typeof window !== 'undefined') {
           <div className="pricing-section">
             <h2>What You Get</h2>
             <ul className="features-list">
-              {FEATURES.map((feature, i) => (
-                <li key={i}>
-                  <span className="check-icon">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="20 6 9 17 4 12" />
-                    </svg>
-                  </span>
-                  {feature}
-                </li>
-              ))}
+              {FEATURES.map((feature, i) => {
+                // Features may be strings or { title, description } objects.
+                // Strings render as-is; objects render title + optional
+                // description. Anything else falls through as text so React
+                // doesn't throw "objects are not valid as a React child".
+                let title, description;
+                if (typeof feature === 'string') {
+                  title = feature;
+                } else if (feature && typeof feature === 'object') {
+                  title = feature.title || feature.name || JSON.stringify(feature);
+                  description = feature.description || feature.desc;
+                } else {
+                  title = String(feature);
+                }
+                return (
+                  <li key={i}>
+                    <span className="check-icon">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    </span>
+                    <span className="feature-text">
+                      <span className="feature-title">{title}</span>
+                      {description && <span className="feature-desc">{description}</span>}
+                    </span>
+                  </li>
+                );
+              })}
             </ul>
             <p className="pricing-cta">Get started — plans start after signup</p>
             <div className="pricing-trust">


### PR DESCRIPTION
## Summary

Landing-page \`PricingSection\` was rendering each feature as a bare React child — fine when the skill passes \`[\"Unlimited usage\", ...]\`, fatal when it passes \`[{title: ..., description: ...}, ...]\`. Second case throws React #31 before mount; tenant page = white screen + console error.

Now the template handles both:
- **string** → renders inline (unchanged behaviour)
- **\`{title, description}\`** → title is semibold primary, description is a smaller muted line underneath
- **anything else** → stringified so the page still renders

Caught during prod QA on 2026-04-20. The \`/vibes:factory\` skill scaffolded a music-rules app and decided the features merited rich objects — that's the *right* agent instinct; the template just needed to honor it instead of exploding.

## Change

\`skills/factory/templates/unified.html\`:
- CSS: \`.features-list li\` aligns flex-start, \`.check-icon\` gets a small top margin, added \`.feature-text\` / \`.feature-title\` / \`.feature-desc\` classes.
- JSX: \`PricingSection\`'s \`FEATURES.map\` now normalizes each entry to \`{title, description}\` before rendering.

## Test plan

- [x] \`bunx vitest run\` in scripts/ — 710/710 pass.
- [ ] After merge + desktop rebuild + tenant redeploy: reload a factory-mode landing page and confirm both shapes render cleanly.

## Related

- [#59](https://github.com/popmechanic/VibesOS/pull/59) — subscribe fetch \`credentials: "include"\` (merged).
- [#60](https://github.com/popmechanic/VibesOS/pull/60) — \`__FACTORY_MODE__\` substitution in non-factory assemblers (merged).