### PR TITLE
fix(factory): read accessToken from auth.json, not token

### DIFF
--- a/skills/factory/SKILL.md
+++ b/skills/factory/SKILL.md
@@ -101,7 +101,7 @@ VIBES_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "${CLAUDE_SKILL_DIR}")")}
 APP_NAME="${1:-}"
 if [ -n "$APP_NAME" ]; then
   curl -s "https://factory.vibesos.com/connect/status/$APP_NAME" \
-    -H "Authorization: Bearer $(cat ~/.vibes/auth.json | grep -o '"token":"[^"]*"' | cut -d'"' -f4)" 2>/dev/null
+    -H "Authorization: Bearer $(cat ~/.vibes/auth.json | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")" 2>/dev/null
 fi
 ```
 
@@ -223,7 +223,7 @@ Description: |
 
 **Get the auth token:**
 ```bash
-TOKEN=$(cat ~/.vibes/auth.json | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null || echo "")
+TOKEN=$(cat ~/.vibes/auth.json | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])" 2>/dev/null || echo "")
 ```
 
 **Create Stripe Connect account:**


### PR DESCRIPTION
## Summary

The factory skill's SKILL.md referenced \`~/.vibes/auth.json['token']\` in two places. That key doesn't exist — the CLI auth helper writes \`{ accessToken, refreshToken, idToken, expiresAt }\`. An agent following SKILL verbatim ended up with an empty \`TOKEN\` variable and every factory-worker call 401'd with \"Missing authorization\".

Both snippets now read \`accessToken\`. The pre-flight snippet also switched from grep-based extraction to the same python3 json.load parse the deploy snippet uses, for consistency.

## Caught by

Prod QA on 2026-04-20 while running the 3-command recovery for a tenant app whose token engine needed re-initializing. I worked around by hand-substituting \`accessToken\`, then followed up with this PR so the next agent run doesn't hit it.

## Test plan

- [x] \`grep -n \"'token'\" skills/factory/SKILL.md\` returns no matches.
- [ ] Running through the factory skill end-to-end with a live login cache produces a non-empty \`TOKEN\` and the configure/initialize curls succeed.