### PR TITLE
chore(factory): drop unused --landing-accent-hover token

### DIFF
--- a/skills/factory/templates/unified.html
+++ b/skills/factory/templates/unified.html
@@ -70,7 +70,6 @@
 
         /* vibes-landing */
         --landing-accent: #0f172a;
-        --landing-accent-hover: #1e293b;
 
         /* vibes-admin */
         --admin-bg: oklch(0.97 0.01 250);


### PR DESCRIPTION
Follow-up from the code review on [VibesOS#63](https://github.com/popmechanic/VibesOS/pull/63).

PR #63 replaced the old btn-start hover color (`var(--landing-accent-hover, ...)`) with a `color-mix(..., 85%, black)` darken on `--comp-accent`. The `--landing-accent-hover` declaration at line 73 of `unified.html` is no longer read by any rule in the template. Removing to keep the `:root` block honest.

Grep confirms zero consumers in the template post-#63.