### PR TITLE
fix(generate): raise output-token floor and instrument max_tokens

### DIFF
--- a/scripts/lib/claude-subprocess.js
+++ b/scripts/lib/claude-subprocess.js
@@ -244,5 +244,12 @@ export function cleanEnv() {
   // Isolate credentials to ~/.vibes/claude-config/ so the vibes-managed
   // binary never reads/writes the user's own ~/.claude/ config.
   env.CLAUDE_CONFIG_DIR = join(homedir(), '.vibes', 'claude-config');
+  // Raise the output-token floor for generation. Vibes apps are typically
+  // produced in a single Write tool call; a 4000-line JSX file easily exceeds
+  // the model default (16K Sonnet / 32K Opus 4.6). Respect a higher user value.
+  const userMaxTokens = parseInt(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || '0', 10);
+  if (!Number.isFinite(userMaxTokens) || userMaxTokens < 64000) {
+    env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '64000';
+  }
   return env;
 }

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -445,6 +445,7 @@ export async function runOneShot(
   let toolsUsed = 0;
   let hasEdited = false;
   let errorSent = false;
+  let hitMaxTokens = false;
   const startTime = Date.now();
   let lastStdoutTime = Date.now();
   let killedByTimeout = false;
@@ -506,6 +507,10 @@ export async function runOneShot(
     const elapsed = getElapsed();
 
     if (event.type === 'assistant' && event.message?.content) {
+      if (event.message.stop_reason === 'max_tokens') {
+        hitMaxTokens = true;
+        console.warn(`[OneShot] PID ${proc.pid} hit max_tokens at ${getElapsed()}s (tools=${toolsUsed}, hasEdited=${hasEdited})`);
+      }
       for (const block of event.message.content) {
         if (block.type === 'tool_use') {
           toolsUsed++;
@@ -612,6 +617,24 @@ export async function runOneShot(
     }
   }
 
+  // max_tokens handling: if the assistant message was truncated at the output
+  // ceiling, surface it. When !hasEdited, the file likely never got written —
+  // treat as a hard error. When hasEdited, the file was written but trailing
+  // content (explanatory text, follow-up edits) may be missing — warn but
+  // continue so the user at least sees a working app.
+  if (hitMaxTokens && !errorSent) {
+    if (!hasEdited) {
+      onEvent({
+        type: 'error',
+        message: 'Claude hit the output token limit before writing the file. Try a simpler prompt, or raise CLAUDE_CODE_MAX_OUTPUT_TOKENS.',
+      });
+      errorSent = true;
+      return null;
+    }
+    console.warn(`[OneShot] max_tokens after file written — trailing content may be truncated`);
+    resultText = (resultText || '') + '\n\n*[Output was truncated at the token limit — the app was written but some follow-up content may be missing.]*';
+  }
+
   // Post-process
   if (hasEdited) {
     sanitizeAppJsx(projectRoot);
@@ -625,6 +648,7 @@ export async function runOneShot(
       elapsed: getElapsed(),
       hasEdited,
       skipChat: opts.skipChat,
+      maxTokensHit: hitMaxTokens,
     });
   }
 

--- a/scripts/server/prompt-builders.ts
+++ b/scripts/server/prompt-builders.ts
@@ -241,18 +241,15 @@ export function buildGeneratePrompt(
       console.log(`[prompt-builders] HTML reference: ${reference.name}, ${htmlContent.length} chars, FULL INLINE (no truncation)`);
       referenceBlock = `=== DESIGN REFERENCE (HTML: "${reference.name}") ===
 
-Study this HTML file's design — colors, typography, spacing, layout, surfaces, effects — and use it as your design spec.
+Study this HTML file's design and use it as your design spec:
 
 \`\`\`html
 ${inlined}
 \`\`\`
 
-Before extracting, quote the key CSS rules from the HTML above — the :root variables, color values, font-family declarations, and major class styles. Then extract the visual design:
-- COLOR PALETTE: map every color to oklch() values for the --comp-* tokens
-- TYPOGRAPHY: font families, weights, sizing hierarchy
-- SURFACES: border styles, shadows, gradients, glass effects
-- LAYOUT PATTERNS: spatial organization, card styles, grid/flex structure
-- MOTION/EFFECTS: animations, transitions, hover states
+Extract and apply — keep any design notes inside CSS comments in the generated file, NOT as narrative prose in the assistant message (output budget is precious):
+- COLOR PALETTE: map every color to oklch() for the --comp-* tokens
+- TYPOGRAPHY, SURFACES, LAYOUT, MOTION: mirror the reference
 - --color-background MUST match the HTML's background. Never transparent.
 
 `;
@@ -264,58 +261,39 @@ Before extracting, quote the key CSS rules from the HTML above — the :root var
       if (intent === 'mood') {
         referenceBlock = `MANDATORY FIRST STEP: Read the image at ${refPath} using the Read tool.
 
-You are extracting a COMPLETE visual theme from this image — as detailed as a professional design system.
+Extract a complete visual theme from this image and apply it to the generated app.
 
-In your <design> block, write out ALL of the following before ANY code:
+IMPORTANT: Keep any design analysis inside CSS comments in the generated <style> tag. Do NOT produce a long <design> narrative in the assistant message before the Write — output budget is precious and narrative prose counts against the same ceiling as the app code.
 
-1. MOOD: 3-4 adjectives (e.g. "warm, editorial, refined, tactile")
-2. COLOR PALETTE — extract EVERY distinct color you see, converted to oklch():
-   - Background color(s): main page bg, card bg, surface bg
-   - Text colors: primary, secondary/muted, headings
-   - Accent color(s): buttons, links, highlights
-   - Border/divider colors
-   - Any gradient stops
-   Write them as a complete :root block with --comp-bg, --comp-text, --comp-border, --comp-accent, --comp-accent-text, --comp-muted, --color-background
-3. TYPOGRAPHY: exact font families (find matching Google Fonts), weights, letter-spacing, text-transform patterns
-4. SURFACES: border-radius values, box-shadow patterns, backdrop-filter, gradients, card styles — with exact CSS
-5. SPACING RHYTHM: padding/margin/gap patterns you observe
-6. DECORATIVE ELEMENTS: background patterns, SVG shapes, dividers, icons style
-7. MOTION ENERGY: calm/lively/dramatic — what animations fit this mood
+Required extractions (apply directly, don't pre-announce):
+- COLOR PALETTE: every distinct color in oklch() — complete :root block with --comp-bg, --comp-text, --comp-border, --comp-accent, --comp-accent-text, --comp-muted, --color-background
+- TYPOGRAPHY: font families (matching Google Fonts), weights, letter-spacing
+- SURFACES: border-radius, shadows, backdrop-filter, gradients
+- DECORATIVE ELEMENTS and MOTION ENERGY: match the mood
 
-Apply the MOOD and COLOR PALETTE from this image to the app you generate.
-Use the extracted oklch() colors EXACTLY in your :root block — do not approximate or simplify.
---color-background MUST match the image's background. Never leave it transparent or unset.
+Use extracted oklch() colors EXACTLY — do not approximate.
+--color-background MUST match the image's background. Never transparent.
 
 `;
       } else {
         // intent === 'match'
         referenceBlock = `MANDATORY FIRST STEP: Read the image at ${refPath} using the Read tool.
 
-You are extracting a COMPLETE visual theme AND layout from this image — as detailed as a professional design system.
+Extract a complete visual theme AND layout from this image and apply it to the generated app.
 
-In your <design> block, write out ALL of the following before ANY code:
+IMPORTANT: Keep any design analysis inside CSS comments in the generated <style> tag. Do NOT produce a long <design> narrative in the assistant message before the Write — output budget is precious and narrative prose counts against the same ceiling as the app code.
 
-1. MOOD: 3-4 adjectives (e.g. "warm, editorial, refined, tactile")
-2. COLOR PALETTE — extract EVERY distinct color you see, converted to oklch():
-   - Background color(s): main page bg, card bg, surface bg
-   - Text colors: primary, secondary/muted, headings
-   - Accent color(s): buttons, links, highlights
-   - Border/divider colors
-   - Any gradient stops
-   Write them as a complete :root block with --comp-bg, --comp-text, --comp-border, --comp-accent, --comp-accent-text, --comp-muted, --color-background
-3. TYPOGRAPHY: exact font families (find matching Google Fonts), weights, letter-spacing, text-transform patterns
-4. SURFACES: border-radius values, box-shadow patterns, backdrop-filter, gradients, card styles — with exact CSS
-5. SPACING RHYTHM: padding/margin/gap patterns you observe
-6. LAYOUT STRUCTURE: how is the space divided? sidebar? header? grid? cards? split-pane? List each section with its approximate proportions
-7. COMPONENT ARRANGEMENT: nav position, content hierarchy, card grid, footer placement
-8. DECORATIVE ELEMENTS: background patterns, SVG shapes, dividers, icons style
-9. MOTION ENERGY: calm/lively/dramatic — what animations fit this mood
+Required extractions (apply directly, don't pre-announce):
+- COLOR PALETTE: every distinct color in oklch() — complete :root block with --comp-bg, --comp-text, --comp-border, --comp-accent, --comp-accent-text, --comp-muted, --color-background
+- TYPOGRAPHY: font families (matching Google Fonts), weights, letter-spacing
+- SURFACES: border-radius, shadows, backdrop-filter, gradients
+- LAYOUT STRUCTURE: how the space is divided (sidebar/header/grid/cards/tabs), component arrangement, spatial proportions
+- DECORATIVE ELEMENTS and MOTION ENERGY: match the mood
 
-Apply BOTH the visual style AND layout structure from this image to the app you generate.
-Use the extracted oklch() colors EXACTLY in your :root block — do not approximate or simplify.
-Match the layout structure, spatial organization, component arrangement, and visual hierarchy of the image.
---color-background MUST match the image's background. Never leave it transparent or unset.
-The goal: the generated app should look like the image was its design spec.
+Use extracted oklch() colors EXACTLY — do not approximate.
+Match the layout structure, spatial organization, and visual hierarchy.
+--color-background MUST match the image's background. Never transparent.
+Goal: the generated app should look like the image was its design spec.
 
 `;
       }
@@ -353,11 +331,10 @@ ${styleGuide}
 
 === DESIGN REASONING ===
 
-Think in a <design> block:
-- What colors, typography, and surfaces did you extract from the reference?
-- How will you map them to --comp-* tokens?
-- What custom SVG illustrations fit this app?
-- What animations and effects match the reference mood? (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
+Briefly note design decisions inside CSS comments in the <style> tag — not as a separate <design> narrative before the Write. Consider:
+- Colors, typography, and surfaces extracted from the reference and their mapping to --comp-* tokens
+- Custom SVG illustrations that fit
+- Animations that match the reference mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
 
 === WRITE app.jsx ===
 
@@ -456,10 +433,10 @@ ${styleGuide}
 
 === DESIGN REASONING ===
 
-Think in a <design> block:
-- How does "${themeName}" personality shape the visual choices?
-- What custom SVG illustrations fit this app?
-- What animations and effects match the theme mood? (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
+Briefly note design decisions inside CSS comments in the <style> tag — not as a separate <design> narrative before the Write. Consider:
+- How "${themeName}" personality shapes visual choices
+- What custom SVG illustrations fit this app
+- What animations match the theme mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
 
 === WRITE app.jsx ===
 


### PR DESCRIPTION
## Summary

Users generating complex apps in the Vibes chat UI were getting stuck mid-generation. Root cause: Claude hits the per-turn `max_tokens` ceiling (32K on Opus 4.6, 16K on Sonnet 4.6) while producing a single large `Write` tool call, and the failure was being silently swallowed as a successful completion.

Three quick-win fixes to make this visible and buy headroom while a proper multi-turn generation split is designed.

- **Env floor** — `cleanEnv()` now sets `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000` as a minimum, respecting higher user values. Important: `cleanEnv()` overrides `CLAUDE_CONFIG_DIR` to `~/.vibes/claude-config/`, which means the fix we've been telling users to apply in their own `~/.claude/settings.json` never actually reached the Vibes subprocess. Env vars are the only lever that crosses this boundary.
- **`stop_reason` instrumentation** — `runOneShot` now detects `stop_reason=max_tokens` on assistant events. Hard-errors with an actionable message when the Write never executed; surfaces a truncation note in the result text when the file was written but trailing content was clipped. A `maxTokensHit` flag also rides on the `complete` event for future UI treatment.
- **Prompt trim** — the image/HTML reference paths in `buildGeneratePrompt` previously forced Claude to write out 7–9 bullet lists of design analysis ("MOOD: ... COLOR PALETTE: ... TYPOGRAPHY: ...") *before* the `Write` call. That was ~1–2K tokens of narrative prose draining the same output ceiling as the generated app. Design notes now live inside CSS comments in the generated `<style>` tag, not as a preamble narrative.

## Why not go straight to multi-turn?

Multi-turn `Write` → `Edit` generation with per-turn `max_tokens` resets is the right long-term architecture, and is the intended follow-up. But it's a real architectural change (moving `generate` onto the persistent bridge, designing a stable `__VIBES_DESIGN__` anchor to prevent drift, handling per-turn progress/cancellation). Shipping the instrumentation first means we'll have telemetry on whether `max_tokens` is actually the dominant failure before committing to the bigger project.

## Test plan

- [x] All 694 unit tests pass (`cd scripts && npm test`)
- [ ] Manual: generate a complex app (e.g. image-reference with match intent) and confirm no silent truncation; if `max_tokens` is hit, check the surfaced message
- [ ] Manual: verify `echo \$CLAUDE_CODE_MAX_OUTPUT_TOKENS` propagates through to the subprocess when set higher than 64000
- [ ] Review the prompt-trim diff to confirm design-quality-critical directives (oklch palette, `--color-background MUST match`, layout matching for `intent=match`) are preserved