### PR TITLE
feat(generate): 2-step app generation with live staged preview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "vibes",
       "source": "./",
       "description": "Vibes is for people who use Claude Code, but don't know how to code.",
-      "version": "0.2.15",
+      "version": "0.3.0",
       "author": {
         "name": "Marcus Estes",
         "email": "marcus@vibes.diy"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibes",
-  "version": "0.2.15",
+  "version": "0.3.0",
   "description": "Vibes is for people who use Claude Code, but don't know how to code.",
   "author": {
     "name": "Marcus Estes",

--- a/docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md
+++ b/docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md
@@ -1,0 +1,375 @@
+# Direction D: Prompt-Driven Multi-Turn Generation
+
+**Date:** 2026-04-23
+**Status:** Design — pending user review
+**Related PR (shipped):** [#68](https://github.com/popmechanic/VibesOS/pull/68) — raise output-token floor and instrument `max_tokens`
+
+---
+
+## Summary
+
+Vibes OS app generation currently asks Claude to produce a complete React app in a single `Write` tool call. For complex apps (4,000+ lines of JSX/CSS with Canvas, SVG, animations), this reliably exceeds per-turn `max_tokens` limits. Users experience this as the generation hanging or producing a broken file.
+
+This spec proposes splitting generation into **two tool calls** via a prompt-level directive, using Claude Code's native tool-loop. Because each `tool_result` triggers a new assistant turn with a fresh `max_tokens` budget, no harness-level orchestration is required. Every change is a UI-layer change — prompt, bridge events, server routes, editor state.
+
+The work also delivers a **live staged preview** UX: the iframe shows the generation progressing in phases (reference asset → skeleton → complete), turning a black-box wait into a watching-it-build-itself experience.
+
+## Goal
+
+Eliminate `max_tokens` truncation during app generation by producing a visible-but-skeletal app in a first `Write` call, then filling in data/interactions/polish with a second `Edit` call. Along the way, improve perceived speed and generation narrative via staged preview updates.
+
+## Non-goals
+
+- **Not adopting the Anthropic Agent SDK** (`resume: sessionId` / `continue: true`). That abstraction is the idiomatic equivalent of the orchestration we explicitly decided not to build. Vibes OS intentionally stays a UI layer over Claude Code's CLI.
+- **Not building a server-side turn orchestrator.** We instruct Claude via the prompt and let Claude Code's native tool loop handle turn progression. This decision follows from the project philosophy: Anthropic's team will out-engineer a single developer on harness innovation, so we do not reinvent what Claude Code already does.
+- **Not adding per-turn model selection** (e.g., Sonnet for skeleton, Opus for polish). That's a future optimization, not this work.
+- **Not modifying the chat flow.** All changes are isolated to generate-path code.
+- **Not adding analytics/telemetry infrastructure.** The success metrics are measured from server logs and user feedback, not a data pipeline.
+
+## Architecture decision: prompt-driven, not orchestrated
+
+During design we explored four approaches:
+
+| Option | Summary | Status |
+|---|---|---|
+| A — Server-orchestrated subprocesses | Spawn three separate `claude -p` processes | Rejected: loses prompt caching across boundaries |
+| B — Pure model-driven in one session | Send one prompt, trust Claude to self-split | Rejected: not a documented pattern, hard to debug |
+| C — Hybrid staged persistent session | Persistent bridge with server-sent staged prompts | Rejected as premature: reinvents what `resume: sessionId` provides natively |
+| **D — Prompt-driven multi-turn** | Tell Claude in the prompt to use Write→Edit; Claude Code's native tool loop handles turn progression | **Selected** |
+
+The decisive insight: **each `tool_result` in Claude Code triggers a new assistant turn with a fresh `max_tokens` budget.** Multiple tool calls in one "generation" are already multi-turn at the harness level. We don't need to orchestrate — we need to ask for the decomposition.
+
+## Turn structure
+
+Claude is instructed to produce the app in **two tool calls**, in order:
+
+### Step 1 — `Write` app.jsx: visible skeleton
+
+Contents:
+- The mandatory `window.__VIBES_THEMES__` and `useVibesTheme()` boilerplate.
+- A `<style>` tag containing the `:root` tokens, plus the four theme marker sections (`@theme:tokens`, `@theme:surfaces`, `@theme:motion`, `@theme:decoration`) — markers present even when sections are empty.
+- Base layout CSS (grid/flex structure, typography, spacing).
+- A functioning component tree with visible elements: header, main content area, whatever structural regions fit the app concept. Components render placeholder/empty states but the layout is real.
+- Basic `useState` for local UI state. No TinyBase hooks yet.
+- `export default App`.
+
+After Step 1 the preview should look like the final app in colors, typography, and layout — just without data or polish.
+
+### Step 2 — `Edit` app.jsx: data, interactions, and polish
+
+Contents:
+- TinyBase hooks (`useRowIds`, `useCell`, `useAddRowCallback`, `useSetCellCallback`, `useDelRowCallback`, `useValue`).
+- React event handlers, effects, refs.
+- `useApp()` integration, optional `useAI` wiring.
+- Canvas 2D or WebGL backgrounds where appropriate.
+- Animated SVG illustrations.
+- Content inside `@theme:surfaces`, `@theme:motion`, `@theme:decoration` markers (shadows, gradients, `@keyframes`, hover effects, scroll reveals).
+
+After Step 2 the app is complete.
+
+### Why two steps, not three
+
+Three steps (skeleton / data / polish) was initially proposed but rejected for this iteration on token-economy and speed grounds:
+
+- Two steps adds ~15% to wall time over single-Write. Three steps would add ~30%.
+- The `max_tokens` budget (64K floor shipped in PR #68, per-turn) is ample for Step 2 even combining data + polish. A full Vibes app is typically 3,000–6,000 output tokens; Step 2's Edit diffs are well within budget.
+- A simpler prompt means higher compliance. The drift risk identified during research is minimized with fewer handoffs.
+- Claude may naturally split Step 2 into multiple `Edit` tool calls anyway. Each of those fires a `preview_reload` event (see Section on Bridge plumbing), so the user may see 3–5 preview refreshes even though we only prescribe 2 steps.
+
+### Why the theme markers live in Step 1
+
+Drift on colors/typography between turns is the highest-quality risk. Locking the `:root` tokens and marker scaffold in Step 1 means Step 2's `Edit` tool can only modify the content *inside* marker sections — it cannot accidentally rewrite the color palette.
+
+This reuses proven infrastructure: the existing multi-pass theme switcher (`buildThemePromptMultiPass` in `scripts/server/prompt-builders.ts`) already uses `@theme:*` markers for scoped edits.
+
+## Prompt rewrite
+
+### Structural shape
+
+The existing single-Write prompt ends with `=== WRITE app.jsx ===` followed by rules. That section is replaced with an explicit two-step protocol:
+
+```
+=== BUILD app.jsx IN TWO TOOL CALLS ===
+
+Build this app in two separate tool calls, in order. Each step has a
+specific purpose; do not try to do everything in one call.
+
+STEP 1 — Write app.jsx: the visible skeleton.
+  (Step 1 content per the Turn Structure section above)
+
+STEP 2 — Edit app.jsx: data, interactions, and polish.
+  (Step 2 content per the Turn Structure section above)
+
+=== RULES THAT APPLY TO ALL STEPS ===
+  (The existing cross-cutting rules: no imports, no TypeScript,
+   no CSS unicode escapes, Tailwind mobile-first, `className="btn"`,
+   `className="grid-background"` on root, TinyBase hooks as globals,
+   `export default App`.)
+```
+
+### What moves and what stays
+
+- **The `<design>` preamble is removed** for the non-reference path (already trimmed in PR #68). Design decisions now live inside CSS comments in Step 1's `<style>` tag.
+- **Reference-path image/HTML extraction stays in Step 1**. Claude reads the reference once, extracts tokens, applies them in the Write.
+- **`useAI` instructions** stay appended at the global level (unchanged). Claude places them naturally in Step 2's data-layer work.
+- **`THEME_SECTION_MARKERS`** stays in the overall prompt context — all steps need to understand markers.
+
+### DRY refactor
+
+The reference and non-reference prompt templates currently duplicate ~60–70% of their content. This work extracts the identical blocks as named constants to eliminate drift risk:
+
+- `USE_VIBES_THEME_TEMPLATE(themeId, themeName)` — returns the `useVibesTheme` JSX block for a given theme id/name.
+- `TWO_STEP_INSTRUCTIONS` — the `=== BUILD app.jsx IN TWO TOOL CALLS ===` section.
+- `GLOBAL_STEP_RULES` — the `=== RULES THAT APPLY TO ALL STEPS ===` block.
+- `DESIGN_REASONING_SECTION(isReference)` — the bullets, parameterized by path.
+
+Both templates then compose as: header + theme-source-section + `${USE_VIBES_THEME_TEMPLATE(...)}` + `${TWO_STEP_INSTRUCTIONS}` + `${GLOBAL_STEP_RULES}` + tail.
+
+Full composition (rebuilding prompts from building-block functions) was considered and rejected — the theme-source sections genuinely differ (file-derived vs. reference-derived) and forcing unified composition there is harder to read than two literal templates that share constants.
+
+Acceptance criterion: a unit test asserts both built prompts contain `TWO_STEP_INSTRUCTIONS` and `GLOBAL_STEP_RULES`, guarding against future re-duplication.
+
+## Bridge + UI plumbing
+
+Three new bridge event types, one new server route, a simple UI state machine. No stream-json protocol changes; everything rides on the existing `onEvent` channel.
+
+### New bridge events
+
+**1. `reference_preview`** — emitted once at the start of a reference-path generation, before any tool calls.
+
+```ts
+{ type: 'reference_preview', src: '/reference-frame?name=<filename>&kind=html|image' }
+```
+
+Emitted from `handleGenerate` when `result.isReference` is known, right before `runOneShot` is called. The UI swaps the iframe src to the provided URL.
+
+**2. `preview_reload`** — emitted after each successful `Write` or `Edit` `tool_result`.
+
+```ts
+{ type: 'preview_reload' }
+```
+
+Emitted from inside `runOneShot`'s stream parser, in the existing `event.type === 'tool_result'` branch, when `!event.is_error` and the corresponding `pendingTools` entry was `Write` or `Edit`. Emission is gated by the JSX validator (below) — a failed validation emits `preview_reload_failed` instead.
+
+**3. `preview_reload_failed`** — emitted when the post-write JSX syntax check fails.
+
+```ts
+{ type: 'preview_reload_failed', stage: 'foundation' | 'interactions', error: string }
+```
+
+Uses `Bun.Transpiler` in JSX mode as a parse-only syntax check:
+
+```ts
+function validateAppJsx(path: string): { ok: true } | { ok: false; error: string } {
+  try {
+    new Bun.Transpiler({ loader: 'jsx' }).transformSync(readFileSync(path, 'utf-8'));
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message || e).slice(0, 500) };
+  }
+}
+```
+
+On failure: the UI does not cache-bust the iframe (last-known-good render stays visible). Overlay flips to a non-fatal error state. Generation continues; a subsequent successful `preview_reload` is treated as recovery.
+
+**4. `generation_stage`** — emitted on stage transitions, drives the overlay copy.
+
+```ts
+{ type: 'generation_stage', stage: 'reading_reference' | 'foundation' | 'interactions' | 'complete' }
+```
+
+Emission points:
+
+- `handleGenerate` → emits `reading_reference` for reference paths, or `foundation` for non-reference paths, right before `runOneShot`.
+- `runOneShot` → tracks a `toolUseSeen` counter. On the first `tool_use` with name `Write` or `Edit`, if the current stage is still `reading_reference`, advance to `foundation`. On the second such `tool_use`, advance to `interactions`. Tool uses for `Read` do not advance the counter — they are setup for the upcoming edit, not a step boundary.
+- `complete` is signaled by the existing `complete` event (no separate stage event).
+
+### Complete event gains a field
+
+```ts
+{ type: 'complete', ..., appJsxValid: boolean }
+```
+
+If `false`, the UI shows a persistent error with a Retry action. Today's silent-hang mode becomes a clean failure signal.
+
+### New server route: `/reference-frame`
+
+Serves the reference asset inside an iframe-friendly wrapper.
+
+- `GET /reference-frame?name=<filename>&kind=html` — reads the file from the known reference upload location (`.vibes-tmp/` or the app dir), returns it with `Content-Type: text/html`.
+- `GET /reference-frame?name=<filename>&kind=image` — wraps the image in a minimal HTML shell (black background, image centered with `max-width:100%; max-height:100vh; object-fit:contain`).
+
+Security: `name` is validated to match a file inside the known reference directory — no path traversal.
+
+### UI state contract
+
+The editor holds two pieces of state during generation:
+
+- `currentStage` — drives the overlay text.
+- `iframeSrc` — `/app-frame` by default, `/reference-frame?...` when a reference preview is active.
+
+Event handlers:
+
+- `reference_preview` → set `iframeSrc` to the provided src.
+- First `preview_reload` after a reference preview → set `iframeSrc` back to `/app-frame`.
+- Every `preview_reload` → cache-bust the iframe (`?t=${Date.now()}`).
+- `generation_stage` → set `currentStage`.
+- `preview_reload_failed` → do not cache-bust; overlay flips to non-fatal error state.
+- `complete` → clear overlay; check `appJsxValid` and surface persistent error if false.
+
+### Overlay spec
+
+Positioned over the preview iframe, semi-transparent so the preview is still visible. Copy:
+
+| Stage | Copy |
+|---|---|
+| `reading_reference` | Analyzing reference — extracting design... |
+| `foundation` | Step 1 of 2 — Foundation |
+| `interactions` | Step 2 of 2 — Building interactions and polish |
+| (complete) | (overlay dismisses) |
+| `preview_reload_failed` during `foundation` | Step 1 produced a syntax error — waiting for retry... |
+| `preview_reload_failed` during `interactions` | Step 2 produced a syntax error — continuing... |
+
+The overlay has `pointer-events: auto` until `complete`, absorbing clicks so users cannot interact with a partially-wired skeleton and mistake broken state for a bug.
+
+## Config changes
+
+All changes to the two `runOneShot` call sites in `scripts/server/handlers/generate.ts`.
+
+### Tools allowlist
+
+All three paths converge to the same allowlist. Read is load-bearing — Claude Code requires the file be read in the conversation before it can be edited.
+
+| Path | Current | New |
+|---|---|---|
+| Non-reference | `'Write'` | `'Write,Edit,Read'` |
+| HTML ref | `'Write'` | `'Write,Edit,Read'` |
+| Image ref | `'Write,Read'` | `'Write,Edit,Read'` |
+
+Because all paths converge, the conditional in `handleGenerate` simplifies to a single `tools` value.
+
+### max-turns
+
+Calibrated to absorb multiple Edits within Step 2:
+
+| Path | Current | New |
+|---|---|---|
+| Non-reference | 5 | 10 |
+| HTML ref | 5 | 10 |
+| Image ref | 8 | 12 |
+
+### Unchanged
+
+- Model selection — still chosen once, applies across the session.
+- Permission mode — `buildClaudeArgs` defaults to `bypassPermissions` when `tools` is set.
+- `CLAUDE_CODE_MAX_OUTPUT_TOKENS` — the 64K floor from PR #68 applies per turn. Each step gets its own ceiling.
+- Extended thinking — Claude Code's adaptive default stays. Tuning this is out of scope.
+
+## Reference-path compatibility
+
+Most reference-path UX is handled by the bridge + UI plumbing. Remaining clarifications:
+
+### Where extraction happens
+
+Image and HTML analysis happens **inside Step 1**, not as a separate phase. The prompt tells Claude to apply extraction directly to the written code rather than producing narrative prose (this directive shipped in PR #68). Step 1 takes ~2–3 extra seconds for reference paths, but produces the same kind of artifact — a visible skeleton with correct theme tokens.
+
+### Step 2 does not re-read the reference
+
+Step 2's prompt for reference paths is identical to the non-reference Step 2 prompt. The reference's visual language is already baked into Step 1's Write; re-reading the image would be a token drain for no design benefit. Tools allowlist includes Read, so Claude *could* re-read if needed, but we do not prompt for it.
+
+### Text-file references with `intent=seed`
+
+The row-seeding logic belongs in Step 2 (data layer), not Step 1. The text content is in the initial prompt (amortized by cache after turn 1), so Step 2 sees it without a re-Read. If testing shows Claude placing seeding logic in Step 1, we add a short line to Step 2's instructions.
+
+### Theme event emissions unchanged
+
+`theme_selected` still fires before generation starts, carrying `themeId: 'custom-ref'` for reference paths. No downstream changes needed.
+
+### Parallel prompts handled by DRY extraction
+
+The two prompt templates (reference and non-reference) share `TWO_STEP_INSTRUCTIONS` and `GLOBAL_STEP_RULES` via constants — guarded by a regression test.
+
+## Rollout
+
+### Release approach
+
+**Hard cutover with `git revert` as the back-out story.**
+
+- Ship the 2-step prompt as the only path. No opt-in flag.
+- Version bump to **0.3.0** (currently 0.2.15). Per `CLAUDE.md`, bump both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+- The shipped instrumentation (`[OneShot] hit max_tokens` log, `maxTokensHit` on complete events) gives us telemetry without needing a flag.
+- If the release is problematic, `git revert` the PR. The old single-Write prompt stays in history.
+
+### Success metrics
+
+Vibes OS does not currently have aggregated telemetry, so "rate" here is judged from two sources: (1) grepping the developer's own server log bucket for the relevant log lines and tallying hits against total generations during the window, and (2) user feedback cadence (number of "stuck generating" reports per week compared to the pre-release baseline). This is adequate for a single-developer project; an analytics layer is out of scope for this work.
+
+Signal watched for two weeks post-release:
+
+| Signal | Source | Target |
+|---|---|---|
+| `[OneShot] hit max_tokens` log lines | server logs | <5% of generations |
+| `preview_reload_failed` emissions | bridge event log | <10% of generations |
+| Two-phase reveal completes (≥2 `preview_reload` events per generation) | bridge event log | >90% of generations — compliance check on the 2-step prompt |
+| Generation wall-time (median) | client-side timing, eyeballed | within ±20% of pre-release baseline |
+| Quality regressions | user reports | none or minor |
+| "Stuck generating" user reports | informal feedback | drops relative to baseline |
+
+The compliance check is the primary leading indicator. If <90% of generations show ≥2 `preview_reload` events, Claude is ignoring the step structure and the prompt needs tightening.
+
+### Back-out criteria
+
+Revert the PR if:
+
+- `preview_reload_failed` rate >25%
+- Median generation wall-time grows >40%
+- User reports of noticeably worse design quality
+
+The shipped `max_tokens` floor and instrumentation stay regardless — independent improvements.
+
+## Testing
+
+### Unit tests (`scripts/__tests__/unit/`)
+
+- Prompt builder emits `TWO_STEP_INSTRUCTIONS` and `GLOBAL_STEP_RULES` in both reference and non-reference paths (regression guard).
+- `buildClaudeArgs` for generate: `--tools Write,Edit,Read` and `--max-turns` at 10/10/12 per path.
+- `validateAppJsx` helper: returns `ok: true` for valid JSX, `ok: false` with error for broken JSX.
+- Stream parser emits `preview_reload` / `preview_reload_failed` / `generation_stage` events in correct order given a synthetic stream-json fixture.
+
+### Integration
+
+Using existing `scripts/__tests__/integration` plumbing, a mocked multi-turn generation (fake stream-json events) verifies the full event sequence:
+
+```
+generation_stage: foundation
+ → preview_reload
+ → generation_stage: interactions
+ → preview_reload
+ → complete (appJsxValid: true)
+```
+
+### Manual checklist
+
+- Non-reference simple app: verify preview updates twice, overlay progresses correctly.
+- Image-reference generation: verify `reference_preview` shows image first, then transitions.
+- HTML-reference generation: same but with HTML.
+- Text-reference with `intent=seed`: verify seeding logic ends up in Step 2.
+- Force a broken Edit (contrived prompt): verify `preview_reload_failed` fires, overlay shows error, next Edit recovers.
+- Run `/vibes:test` end-to-end.
+
+## Effort estimate
+
+- Prompt rewrite + DRY refactor: 1–2 hours
+- Bridge event additions + JSX validator: 2–3 hours
+- UI (reference-frame route, overlay, iframe swap/reload logic): 3–4 hours
+- Test updates: 1–2 hours
+- Manual test pass: 1–2 hours
+
+**Total: ~10–13 hours** — a focused day or spread across two evenings.
+
+## Open questions / future work
+
+- **Per-turn model selection.** Could ship as a follow-up: Sonnet for skeleton (speed), Opus for polish (richness). Out of scope for this work; needs its own design conversation.
+- **Extended thinking tuning.** The adaptive default applies per turn. If `max_tokens` still pressure-tests after this ships, disabling thinking on Step 2 (where the work is mechanical) could reclaim budget.
+- **Step 2 truncation mitigation.** If Step 2 itself starts hitting `max_tokens` for the largest apps, the natural next step is to prescribe three steps (splitting data from polish). The instrumentation will tell us.
+- **Analytics.** Vibes OS currently lacks aggregated telemetry. Success metrics are measured from logs and feedback. Adding a thin analytics layer is a separate, future project.

--- a/docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md
+++ b/docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md
@@ -1,0 +1,1551 @@
+# Direction D Multi-Turn Generation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split Vibes OS app generation into two tool calls (Write skeleton → Edit rest) using Claude Code's native tool loop, with a live staged preview UX that shows the reference asset, then the skeleton, then the complete app.
+
+**Architecture:** Prompt-driven multi-turn — no harness orchestration, no Agent SDK. Changes are prompt edits, server-side event emissions, a new `/reference-frame` route, a JSX syntax validator, and editor-UI plumbing in `editor.html`.
+
+**Tech Stack:** Bun, TypeScript/JavaScript, vitest, Claude Code CLI subprocess, stream-json parsing, WebSocket → editor UI.
+
+**Spec:** [docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md](2026-04-23-direction-d-multi-turn-generation-design.md)
+
+---
+
+## File Structure
+
+### Modified files
+
+- `scripts/server/prompt-builders.ts` — add shared constants (`USE_VIBES_THEME_TEMPLATE`, `TWO_STEP_INSTRUCTIONS`, `GLOBAL_STEP_RULES`, `DESIGN_REASONING_SECTION`); rewrite `buildGeneratePrompt` for 2-step structure.
+- `scripts/server/handlers/generate.ts` — emit `reference_preview` + initial `generation_stage` before `runOneShot`; update `runOneShot` call sites (tools allowlist, maxTurns).
+- `scripts/server/claude-bridge.ts` — emit `preview_reload` (gated by JSX validator), `preview_reload_failed`, `generation_stage` from `runOneShot`; track `toolUseSeen` counter; add `appJsxValid` field on the `complete` event.
+- `scripts/server/router.ts` — register `GET /reference-frame` route.
+- `scripts/__tests__/unit/prompt-builders.test.ts` — add assertions for shared constants and 2-step structure.
+- `scripts/__tests__/unit/claude-subprocess.test.js` — update any tools/maxTurns expectations that now differ.
+- `skills/vibes/templates/editor.html` — add overlay component over preview iframe; wire WebSocket `onmessage` to handle new events; implement iframe-src swap and cache-bust logic.
+- `.claude-plugin/plugin.json` — bump version to `0.3.0`.
+- `.claude-plugin/marketplace.json` — bump version to `0.3.0`.
+
+### New files
+
+- `scripts/lib/validate-app-jsx.ts` — JSX syntax check helper using `Bun.Transpiler`.
+- `scripts/__tests__/unit/validate-app-jsx.test.ts` — tests for validator.
+- `scripts/server/handlers/reference-frame.ts` — `GET /reference-frame` handler for image and HTML references.
+- `scripts/__tests__/unit/reference-frame.test.ts` — tests for the new route handler.
+
+### File-by-file responsibilities
+
+| File | Responsibility |
+|---|---|
+| `prompt-builders.ts` | Build the 2-step generate prompt with DRY'd shared constants |
+| `generate.ts` | Orchestrate generation; emit pre-run UI events; pass the right tools/maxTurns |
+| `claude-bridge.ts` | Stream-json subprocess wrapper; emits UI events from assistant/tool events |
+| `validate-app-jsx.ts` | Pure function: parse-check `app.jsx` via Bun.Transpiler, return ok/error |
+| `reference-frame.ts` | Serve the reference asset (HTML passthrough; image full-bleed wrapper) |
+| `editor.html` | Render overlay state + swap/cache-bust iframe in response to events |
+
+---
+
+## Phase 1 — Prompt refactor + DRY extraction
+
+**Commit boundary at end of phase.** At this point app generation still works single-Write — we haven't changed behavior yet, just reorganized prompt code so subsequent tasks can edit one place.
+
+### Task 1.1: Add a regression test for shared prompt constants
+
+**Files:**
+- Modify: `scripts/__tests__/unit/prompt-builders.test.ts`
+
+- [ ] **Step 1: Add a failing test asserting both generate paths contain the shared constants**
+
+Append this `describe` block to `prompt-builders.test.ts` (at the end of the file, before the final closing bracket if there is one; otherwise at top level):
+
+```typescript
+describe('buildGeneratePrompt shared constants (DRY refactor)', () => {
+  it('non-reference path contains TWO_STEP_INSTRUCTIONS and GLOBAL_STEP_RULES', () => {
+    writeFileSync(join(TMP, 'themes', 'abstract.txt'), ':root { --color-background: oklch(20% 0 0); }');
+    const ctx = makeCtx({
+      themes: [{ id: 'abstract', name: 'Abstract' }],
+      themeColors: { abstract: { bg: '#000', rootBlock: ':root { --color-background: oklch(20% 0 0); }' } },
+    });
+    const result = buildGeneratePrompt(ctx as any, 'a todo list', { themeId: 'abstract' });
+    expect(result.prompt).toContain('=== BUILD app.jsx IN TWO TOOL CALLS ===');
+    expect(result.prompt).toContain('STEP 1 — Write app.jsx');
+    expect(result.prompt).toContain('STEP 2 — Edit app.jsx');
+    expect(result.prompt).toContain('=== RULES THAT APPLY TO ALL STEPS ===');
+  });
+
+  it('reference path (HTML) contains the same TWO_STEP_INSTRUCTIONS and GLOBAL_STEP_RULES', () => {
+    const refPath = join(TMP, 'ref.html');
+    writeFileSync(refPath, '<html><body style="background:#f00">Hi</body></html>');
+    const ctx = makeCtx();
+    const result = buildGeneratePrompt(ctx as any, 'match this', {
+      reference: { name: 'ref.html', serverPath: refPath, intent: 'match' },
+    });
+    expect(result.prompt).toContain('=== BUILD app.jsx IN TWO TOOL CALLS ===');
+    expect(result.prompt).toContain('STEP 1 — Write app.jsx');
+    expect(result.prompt).toContain('STEP 2 — Edit app.jsx');
+    expect(result.prompt).toContain('=== RULES THAT APPLY TO ALL STEPS ===');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `cd scripts && npm run test:unit -- prompt-builders`
+Expected: FAIL — both assertions fail because the current prompt uses `=== WRITE app.jsx ===`, not the new two-step framing.
+
+### Task 1.2: Extract `USE_VIBES_THEME_TEMPLATE` helper
+
+**Files:**
+- Modify: `scripts/server/prompt-builders.ts`
+
+- [ ] **Step 1: Add the helper near the top of the file, under existing imports**
+
+Insert after the `EFFECT_INSTRUCTIONS` constant (around line 34):
+
+```typescript
+/**
+ * The boilerplate JSX block every generated app.jsx must start with.
+ * Shared between the reference and non-reference paths.
+ */
+function USE_VIBES_THEME_TEMPLATE(themeId: string, themeName: string): string {
+  return `\`\`\`jsx
+window.__VIBES_THEMES__ = [{ id: "${themeId}", name: "${themeName}" }];
+
+function useVibesTheme() {
+  const [theme, setTheme] = React.useState(() => localStorage.getItem("vibes-theme") || "${themeId}");
+  React.useEffect(() => {
+    const handler = (e) => { const t = e.detail?.theme; if (t) { setTheme(t); localStorage.setItem("vibes-theme", t); } };
+    document.addEventListener("vibes-design-request", handler);
+    return () => document.removeEventListener("vibes-design-request", handler);
+  }, []);
+  return theme;
+}
+\`\`\``;
+}
+```
+
+- [ ] **Step 2: Replace the inline useVibesTheme blocks in `buildGeneratePrompt`**
+
+In the reference-path prompt (inside `if (hasRef) { ... }`), find the string literal containing the `useVibesTheme` function and replace that entire fenced code block with `${USE_VIBES_THEME_TEMPLATE('custom-ref', 'Custom Reference')}`.
+
+In the non-reference-path prompt (`const prompt = \`... \``), find the same block and replace with `${USE_VIBES_THEME_TEMPLATE(themeId!, themeName)}`.
+
+- [ ] **Step 3: Run existing tests to make sure nothing broke**
+
+Run: `cd scripts && npm run test:unit -- prompt-builders`
+Expected: existing tests still pass. The new test from Task 1.1 still fails (different reason now — or same).
+
+### Task 1.3: Extract `GLOBAL_STEP_RULES` constant
+
+**Files:**
+- Modify: `scripts/server/prompt-builders.ts`
+
+- [ ] **Step 1: Add the constant**
+
+Insert after `USE_VIBES_THEME_TEMPLATE`:
+
+```typescript
+/**
+ * Cross-cutting rules that apply to every step of the 2-step generation.
+ * Kept in one place so the reference and non-reference prompts share identical text.
+ */
+const GLOBAL_STEP_RULES = `=== RULES THAT APPLY TO ALL STEPS ===
+
+- NO import statements — the app runs in a Babel script block with globals
+- NO TypeScript. End the file with: export default App
+- Never use CSS unicode escapes (\\2192, \\2022, \\00BB). Use actual Unicode characters: → ● « etc. CSS escapes break Babel.
+- Responsive (mobile-first with Tailwind). Use className="btn" for buttons, className="grid-background" on the root element.
+- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue, useSortedRowIds, useTable) are PRE-EXISTING GLOBALS. NEVER import, redeclare, or alias them.
+- Table names must be string literals: useRowIds('todos'), never useRowIds(tableName).
+- Cells are scalars only (string/number/boolean) — no nested objects or arrays.
+- No sync/connection status UI, not even decorative ("Online", "LIVE", "Connected") — SyncStatusDot is built-in.
+- useApp() is mandatory in root App. It returns { isReady, isSyncing, user }.`;
+```
+
+- [ ] **Step 2: Leave existing prompt strings alone for now** — we'll fold this in after `TWO_STEP_INSTRUCTIONS` is added in Task 1.4.
+
+### Task 1.4: Extract `TWO_STEP_INSTRUCTIONS` constant
+
+**Files:**
+- Modify: `scripts/server/prompt-builders.ts`
+
+- [ ] **Step 1: Add the constant**
+
+Insert after `GLOBAL_STEP_RULES`:
+
+```typescript
+/**
+ * The core new behavior: tell Claude to produce the app via two tool calls.
+ * Claude Code's native tool loop turns each tool_result into a new assistant turn
+ * with its own fresh max_tokens budget — so we don't need server-side orchestration.
+ */
+const TWO_STEP_INSTRUCTIONS = `=== BUILD app.jsx IN TWO TOOL CALLS ===
+
+Build this app in two separate tool calls, in order. Each step has a specific purpose; do not try to do everything in one call.
+
+STEP 1 — Write app.jsx: the visible skeleton.
+Produce a file that compiles and renders the app's basic shape — even without data or interactions. Include:
+- The exact __VIBES_THEMES__ + useVibesTheme code from above (unchanged)
+- A <style> tag with :root tokens and the four marker sections (/* @theme:tokens */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS
+- A functioning component tree with visible elements: header with the app title, main content area, whatever structural regions fit this app (sidebar/nav/footer as needed). Components render placeholder/empty states but the layout is real.
+- Basic React hooks for local UI state (useState). NO TinyBase hooks yet. NO event handlers yet.
+- export default App
+
+After STEP 1 the preview should look like the final app in colors, typography, and layout — just without data or polish.
+
+STEP 2 — Edit app.jsx: data, interactions, and polish.
+Read app.jsx (the skeleton you just wrote), then Edit it to add everything else:
+- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue)
+- React event handlers, effects, refs
+- useApp() integration; useAI wiring if the app needs it
+- Inside the @theme:surfaces marker: shadows, borders, gradients, glass effects
+- Inside the @theme:motion marker: @keyframes, CSS @property animations, hover effects
+- Inside the @theme:decoration marker: SVG illustrations, Canvas 2D or WebGL backgrounds, decorative patterns
+
+After STEP 2 the app is complete.
+
+IMPORTANT: Do NOT produce a <design> narrative before STEP 1. Any design notes belong inside CSS comments in the <style> tag. Narrative prose counts against the same output budget as your code.`;
+```
+
+### Task 1.5: Swap the new blocks into both prompt paths
+
+**Files:**
+- Modify: `scripts/server/prompt-builders.ts` (function `buildGeneratePrompt`)
+
+- [ ] **Step 1: Update the reference-path final prompt**
+
+Find the reference-path `refPrompt` template string assignment (inside `if (hasRef)`). Its tail currently looks like:
+
+```typescript
+  ${THEME_SECTION_MARKERS}
+${useAI ? AI_INSTRUCTIONS_GENERATE : ''}`;
+```
+
+Replace the section that begins with `=== WRITE app.jsx ===` through the `- Responsive ...` rule (the whole old Write-instructions + rules block) with:
+
+```typescript
+${TWO_STEP_INSTRUCTIONS}
+
+${GLOBAL_STEP_RULES}
+
+${THEME_SECTION_MARKERS}
+${useAI ? AI_INSTRUCTIONS_GENERATE : ''}`;
+```
+
+The `=== DESIGN REASONING ===` section stays as-is (already trimmed in PR #68).
+
+- [ ] **Step 2: Update the non-reference-path final prompt**
+
+Find the non-reference `prompt` template string (after the `if (hasRef) { return ... }` block). Do the same swap: replace the `=== WRITE app.jsx ===` through rules block with the same two constants.
+
+- [ ] **Step 3: Run the test suite**
+
+Run: `cd scripts && npm run test:unit`
+Expected: all 694 existing tests pass; the two new tests from Task 1.1 now PASS.
+
+### Task 1.6: Commit Phase 1
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add scripts/server/prompt-builders.ts scripts/__tests__/unit/prompt-builders.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(generate): extract shared prompt constants; switch to 2-step instructions
+
+Pulls the useVibesTheme boilerplate, global step rules, and the new
+two-tool-call framing into named constants so the reference and
+non-reference prompt paths share identical text. Regression test guards
+against re-duplication.
+
+This is the core behavioral change for Direction D: Claude is now told
+to split app generation into Write (skeleton) + Edit (rest), taking
+advantage of Claude Code's native tool loop so each step gets its own
+fresh max_tokens budget.
+EOF
+)"
+```
+
+---
+
+## Phase 2 — Config changes (tools + maxTurns)
+
+**Commit boundary at end of phase.** This is where the generate handler opts in to the new multi-tool-call flow.
+
+### Task 2.1: Update generate handler tools + maxTurns
+
+**Files:**
+- Modify: `scripts/server/handlers/generate.ts:59-65`
+
+- [ ] **Step 1: Update the reference-path runOneShot call**
+
+Find the current code:
+
+```typescript
+if (result.isReference) {
+  const maxTurns = result.isHtmlRef ? 5 : 8;
+  console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: result.isHtmlRef ? 'Write' : 'Write,Read' }, onEvent, ctx.projectRoot);
+} else {
+  console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 5, model, cwd: appDir, tools: 'Write' }, onEvent, ctx.projectRoot);
+}
+```
+
+Replace with:
+
+```typescript
+if (result.isReference) {
+  const maxTurns = result.isHtmlRef ? 10 : 12;
+  console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+} else {
+  console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd scripts && npm run test:unit`
+Expected: all tests pass. If any test in `claude-subprocess.test.js` hard-coded `tools: 'Write'` or `maxTurns: 5` for generate, update those assertions to match the new values.
+
+### Task 2.2: Commit Phase 2
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add scripts/server/handlers/generate.ts scripts/__tests__/
+git commit -m "$(cat <<'EOF'
+feat(generate): allow Edit + Read tools, raise max-turns for 2-step flow
+
+All three generate paths (non-reference, HTML ref, image ref) now share
+the Write,Edit,Read allowlist required for Step 2 to edit the skeleton
+Step 1 wrote. Max-turns raised from 5/5/8 to 10/10/12 to absorb Claude's
+natural tendency to split Step 2 into multiple Edit calls.
+EOF
+)"
+```
+
+---
+
+## Phase 3 — JSX validator utility
+
+**Commit boundary at end of phase.** Independent module; does nothing on its own until Phase 4 wires it in.
+
+### Task 3.1: Write validator tests
+
+**Files:**
+- Create: `scripts/__tests__/unit/validate-app-jsx.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+/**
+ * Tests for validateAppJsx — parse-check app.jsx using Bun.Transpiler.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { validateAppJsx } from '../../lib/validate-app-jsx.ts';
+
+const TMP = join(import.meta.dirname, '.tmp-validate-test');
+
+beforeEach(() => { mkdirSync(TMP, { recursive: true }); });
+afterEach(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+describe('validateAppJsx', () => {
+  it('returns ok for a minimal valid component', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'function App() { return <div>Hi</div>; }\nexport default App;');
+    expect(validateAppJsx(p)).toEqual({ ok: true });
+  });
+
+  it('returns ok for JSX that uses TinyBase-style globals (no imports)', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, `
+      function App() {
+        const ids = useRowIds('todos');
+        return <ul>{ids.map(id => <li key={id} />)}</ul>;
+      }
+      export default App;
+    `);
+    expect(validateAppJsx(p)).toEqual({ ok: true });
+  });
+
+  it('returns not-ok with error for unclosed JSX tag', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'function App() { return <div>Hi; }\nexport default App;');
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.length).toBeGreaterThan(0);
+  });
+
+  it('returns not-ok for unterminated template literal', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'const s = `hello world');
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+  });
+
+  it('truncates long error messages to 500 chars', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, '(' .repeat(2000));
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.length).toBeLessThanOrEqual(500);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `cd scripts && npm run test:unit -- validate-app-jsx`
+Expected: FAIL — `validateAppJsx` module not found.
+
+### Task 3.2: Implement the validator
+
+**Files:**
+- Create: `scripts/lib/validate-app-jsx.ts`
+
+- [ ] **Step 1: Create the module**
+
+```typescript
+/**
+ * Parse-check app.jsx using Bun.Transpiler in JSX mode.
+ *
+ * Called from the generate flow after each successful Write/Edit tool_result
+ * to decide whether to emit preview_reload (file is parseable, iframe can
+ * safely refresh) or preview_reload_failed (last-known-good render should
+ * stay on screen).
+ *
+ * Note: this is a syntax-only check. It does not catch React runtime errors,
+ * missing globals, or broken prop shapes — the in-browser Babel load in the
+ * preview iframe is the final arbiter for those.
+ */
+
+import { readFileSync } from 'fs';
+
+export type ValidateResult = { ok: true } | { ok: false; error: string };
+
+export function validateAppJsx(path: string): ValidateResult {
+  try {
+    const code = readFileSync(path, 'utf-8');
+    new Bun.Transpiler({ loader: 'jsx' }).transformSync(code);
+    return { ok: true };
+  } catch (e: any) {
+    const msg = String(e?.message ?? e);
+    return { ok: false, error: msg.slice(0, 500) };
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd scripts && npm run test:unit -- validate-app-jsx`
+Expected: all 5 tests PASS.
+
+### Task 3.3: Commit Phase 3
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add scripts/lib/validate-app-jsx.ts scripts/__tests__/unit/validate-app-jsx.test.ts
+git commit -m "$(cat <<'EOF'
+feat(lib): add validateAppJsx parse-check helper
+
+Uses Bun.Transpiler in JSX mode as a fast, parse-only sanity check.
+Consumed by the bridge in Phase 4 to decide whether to fire
+preview_reload or preview_reload_failed after each Write/Edit tool_result.
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Bridge event emission
+
+**Commit boundary at end of phase.** Telemetry and UI events are emitted; no UI consumer yet (Phase 6 adds that). This phase is safe to ship alone — unknown events are ignored by the current editor.
+
+### Task 4.1: Add import + state for the new events in runOneShot
+
+**Files:**
+- Modify: `scripts/server/claude-bridge.ts`
+
+- [ ] **Step 1: Add the import at the top of the file, near other lib imports**
+
+Find the existing imports (around lines 11-13):
+
+```typescript
+import { createStreamParser } from '../lib/stream-parser.js';
+import { buildPersistentArgs, resolveClaudeBin, cleanEnv } from '../lib/claude-subprocess.js';
+import { translateStreamEvent } from './event-translator.ts';
+```
+
+Add after them:
+
+```typescript
+import { validateAppJsx } from '../lib/validate-app-jsx.ts';
+```
+
+- [ ] **Step 2: Add a `toolUseSeen` counter and a `currentStage` tracker to runOneShot**
+
+In `runOneShot`, find the existing counters block (around line 445):
+
+```typescript
+  let stderrBuffer = '';
+  let resultText = '';
+  let toolsUsed = 0;
+  let hasEdited = false;
+  let errorSent = false;
+  let hitMaxTokens = false;
+  const startTime = Date.now();
+```
+
+Add two lines:
+
+```typescript
+  let stderrBuffer = '';
+  let resultText = '';
+  let toolsUsed = 0;
+  let hasEdited = false;
+  let errorSent = false;
+  let hitMaxTokens = false;
+  let toolUseSeen = 0; // counts Write/Edit tool_use events; drives generation_stage transitions
+  let currentStage: 'reading_reference' | 'foundation' | 'interactions' | null = null;
+  const startTime = Date.now();
+```
+
+### Task 4.2: Emit `generation_stage: interactions` on the second Write/Edit tool_use
+
+**Files:**
+- Modify: `scripts/server/claude-bridge.ts` (inside `runOneShot`'s stream parser)
+
+- [ ] **Step 1: Update the tool_use block-processing branch**
+
+Find the existing `block.type === 'tool_use'` handling (around line 517):
+
+```typescript
+      for (const block of event.message.content) {
+        if (block.type === 'tool_use') {
+          toolsUsed++;
+          const toolName = block.name || '';
+          if (toolName === 'Edit' || toolName === 'Write') hasEdited = true;
+          const inputSummary = summarizeInput(block);
+
+          if (block.id) {
+            pendingTools.set(block.id, { name: toolName, filePath: inputSummary });
+          }
+
+          onEvent({ type: 'tool_detail', name: toolName, input_summary: inputSummary, elapsed });
+          onEvent({ type: 'progress', ...calcProgressLocal(), elapsed });
+        }
+```
+
+Replace with:
+
+```typescript
+      for (const block of event.message.content) {
+        if (block.type === 'tool_use') {
+          toolsUsed++;
+          const toolName = block.name || '';
+          if (toolName === 'Edit' || toolName === 'Write') hasEdited = true;
+          const inputSummary = summarizeInput(block);
+
+          if (block.id) {
+            pendingTools.set(block.id, { name: toolName, filePath: inputSummary });
+          }
+
+          // Advance the generation stage on Write/Edit boundaries. Read tool
+          // uses don't count — they're setup, not a step boundary.
+          if (toolName === 'Write' || toolName === 'Edit') {
+            toolUseSeen++;
+            if (toolUseSeen === 1 && currentStage === 'reading_reference') {
+              currentStage = 'foundation';
+              onEvent({ type: 'generation_stage', stage: 'foundation' });
+            } else if (toolUseSeen === 2) {
+              currentStage = 'interactions';
+              onEvent({ type: 'generation_stage', stage: 'interactions' });
+            }
+          }
+
+          onEvent({ type: 'tool_detail', name: toolName, input_summary: inputSummary, elapsed });
+          onEvent({ type: 'progress', ...calcProgressLocal(), elapsed });
+        }
+```
+
+### Task 4.3: Emit `preview_reload` / `preview_reload_failed` on tool_result
+
+**Files:**
+- Modify: `scripts/server/claude-bridge.ts` (inside the tool_result branch)
+
+- [ ] **Step 1: Add validator-gated emission**
+
+Find the existing `event.type === 'tool_result'` branch (around line 530):
+
+```typescript
+    } else if (event.type === 'tool_result') {
+      const toolDetail = event.tool_use_id ? pendingTools.get(event.tool_use_id) : undefined;
+      if (event.tool_use_id) pendingTools.delete(event.tool_use_id);
+
+      onEvent({
+        type: 'tool_result',
+        name: event.tool_name || '',
+        content: (typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '')).slice(0, 500),
+        is_error: !!event.is_error,
+        elapsed,
+        _filePath: toolDetail?.filePath || '',
+        _toolName: toolDetail?.name || event.tool_name || '',
+      });
+    }
+```
+
+Replace with:
+
+```typescript
+    } else if (event.type === 'tool_result') {
+      const toolDetail = event.tool_use_id ? pendingTools.get(event.tool_use_id) : undefined;
+      if (event.tool_use_id) pendingTools.delete(event.tool_use_id);
+
+      onEvent({
+        type: 'tool_result',
+        name: event.tool_name || '',
+        content: (typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '')).slice(0, 500),
+        is_error: !!event.is_error,
+        elapsed,
+        _filePath: toolDetail?.filePath || '',
+        _toolName: toolDetail?.name || event.tool_name || '',
+      });
+
+      // After a successful Write/Edit, parse-check app.jsx. If it parses,
+      // signal the UI to refresh the preview iframe. If it fails, surface
+      // the error without reloading — the last-known-good render stays.
+      const wasWriteOrEdit = toolDetail?.name === 'Write' || toolDetail?.name === 'Edit';
+      const targetedAppJsx = typeof toolDetail?.filePath === 'string' && toolDetail.filePath.endsWith('app.jsx');
+      if (wasWriteOrEdit && targetedAppJsx && !event.is_error) {
+        const v = validateAppJsx(toolDetail!.filePath);
+        if (v.ok) {
+          onEvent({ type: 'preview_reload' });
+        } else {
+          onEvent({
+            type: 'preview_reload_failed',
+            stage: currentStage === 'interactions' ? 'interactions' : 'foundation',
+            error: v.error,
+          });
+        }
+      }
+    }
+```
+
+### Task 4.4: Add `appJsxValid` to the complete event
+
+**Files:**
+- Modify: `scripts/server/claude-bridge.ts` (near the end of runOneShot)
+
+- [ ] **Step 1: Add a final validation + field on complete**
+
+Find the block near the end of `runOneShot` (around line 625):
+
+```typescript
+  if (!errorSent) {
+    onEvent({
+      type: 'complete',
+      text: resultText || 'Done.',
+      toolsUsed,
+      elapsed: getElapsed(),
+      hasEdited,
+      skipChat: opts.skipChat,
+      maxTokensHit: hitMaxTokens,
+    });
+  }
+```
+
+Replace with:
+
+```typescript
+  let appJsxValid: boolean | undefined = undefined;
+  if (hasEdited && opts.cwd) {
+    const appPath = `${opts.cwd}/app.jsx`;
+    try {
+      appJsxValid = validateAppJsx(appPath).ok;
+    } catch {
+      appJsxValid = false;
+    }
+  }
+
+  if (!errorSent) {
+    onEvent({
+      type: 'complete',
+      text: resultText || 'Done.',
+      toolsUsed,
+      elapsed: getElapsed(),
+      hasEdited,
+      skipChat: opts.skipChat,
+      maxTokensHit: hitMaxTokens,
+      appJsxValid,
+    });
+  }
+```
+
+### Task 4.5: Emit initial `generation_stage` from generate handler
+
+**Files:**
+- Modify: `scripts/server/handlers/generate.ts`
+
+- [ ] **Step 1: Emit the pre-run stage event**
+
+Find the `runOneShot` call sites (lines 60-64 after Task 2.1's edits). Insert a `generation_stage` emission right before them:
+
+```typescript
+if (result.isReference) {
+  const maxTurns = result.isHtmlRef ? 10 : 12;
+  console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  onEvent({ type: 'generation_stage', stage: 'reading_reference' });
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+} else {
+  console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  onEvent({ type: 'generation_stage', stage: 'foundation' });
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+}
+```
+
+### Task 4.6: Thread `currentStage` into runOneShot via opts
+
+**Files:**
+- Modify: `scripts/server/claude-bridge.ts`
+
+The generate handler emitted the initial stage, but runOneShot needs to know the starting stage so its first-tool-use logic knows whether to advance to `foundation` or not.
+
+- [ ] **Step 1: Add an `initialStage` field to `OneShotOpts`**
+
+Find `OneShotOpts`:
+
+```typescript
+export interface OneShotOpts {
+  maxTurns?: number;
+  model?: string;
+  tools?: string;
+  cwd?: string;
+  skipChat?: boolean;
+  permissionMode?: string;
+  /** Operation type for the lock (default: 'chat'). Set to false to skip auto-locking. */
+  lockType?: string | false;
+}
+```
+
+Add one field:
+
+```typescript
+export interface OneShotOpts {
+  maxTurns?: number;
+  model?: string;
+  tools?: string;
+  cwd?: string;
+  skipChat?: boolean;
+  permissionMode?: string;
+  /** Operation type for the lock (default: 'chat'). Set to false to skip auto-locking. */
+  lockType?: string | false;
+  /** Initial generation_stage, used by the tool_use counter to decide when
+   * to emit the foundation → interactions transition. Only passed by the
+   * generate handler; chat/theme paths leave it undefined. */
+  initialStage?: 'reading_reference' | 'foundation';
+}
+```
+
+- [ ] **Step 2: Initialize `currentStage` from opts**
+
+Change the declaration to seed from opts:
+
+```typescript
+  let currentStage: 'reading_reference' | 'foundation' | 'interactions' | null = opts.initialStage ?? null;
+```
+
+- [ ] **Step 3: Pass `initialStage` from generate.ts**
+
+Update the two `runOneShot` calls in `handleGenerate`:
+
+```typescript
+if (result.isReference) {
+  const maxTurns = result.isHtmlRef ? 10 : 12;
+  console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  onEvent({ type: 'generation_stage', stage: 'reading_reference' });
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read', initialStage: 'reading_reference' }, onEvent, ctx.projectRoot);
+} else {
+  console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
+  onEvent({ type: 'generation_stage', stage: 'foundation' });
+  await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read', initialStage: 'foundation' }, onEvent, ctx.projectRoot);
+}
+```
+
+### Task 4.7: Emit `reference_preview` from generate handler
+
+**Files:**
+- Modify: `scripts/server/handlers/generate.ts`
+
+- [ ] **Step 1: Emit the reference preview event for HTML and image references**
+
+Text-file references (.txt/.md/.csv/.tsv/.json/.xml/.rtf) are deliberately **not** shown in the preview — their textual content doesn't visualize usefully, and the user already saw the content when they uploaded it. The event is emitted only for HTML and image refs, and only if the file is findable under `.vibes-tmp/`.
+
+Just before the `onEvent({ type: 'generation_stage', stage: 'reading_reference' })` line added in Task 4.5, add:
+
+```typescript
+  const refName = reference?.name as string | undefined;
+  const isTextRef = !!refName && /\.(txt|md|csv|tsv|json|xml|rtf)$/i.test(refName);
+  if (refName && !isTextRef) {
+    const refKind = result.isHtmlRef ? 'html' : 'image';
+    const vibesTmpPath = join(ctx.projectRoot, '.vibes-tmp', refName);
+    if (existsSync(vibesTmpPath)) {
+      onEvent({
+        type: 'reference_preview',
+        src: `/reference-frame?name=${encodeURIComponent(refName)}&kind=${refKind}`,
+      });
+    }
+  }
+  onEvent({ type: 'generation_stage', stage: 'reading_reference' });
+```
+
+Make sure `join` and `existsSync` are imported at the top of `generate.ts` — they already are for the existing `assembleAppFrame` function.
+
+### Task 4.8: Run the full test suite
+
+- [ ] **Step 1: Run tests**
+
+Run: `cd scripts && npm run test:unit`
+Expected: all tests pass. No new tests added yet for bridge emissions — those are covered by the integration-style fixture test in Task 4.9.
+
+### Task 4.9: Add a bridge event-ordering unit test
+
+**Files:**
+- Create: `scripts/__tests__/unit/generation-events.test.ts`
+
+- [ ] **Step 1: Create a test using a fake stream to verify event order**
+
+```typescript
+/**
+ * Verify that runOneShot's stream parser emits the right sequence of
+ * generation_stage and preview_reload events given synthetic stream-json
+ * input for a 2-step generation.
+ */
+import { describe, it, expect } from 'vitest';
+import { createStreamParser } from '../../lib/stream-parser.js';
+// Note: this test exercises the stream parser + translator contract used
+// by runOneShot. The full runOneShot has subprocess side effects, so we
+// test the event-emission logic by feeding synthetic events through a
+// helper that mirrors runOneShot's parse dispatch. Keep this test in lock-step
+// with the dispatch in claude-bridge.ts#runOneShot.
+
+// If runOneShot's parse callback is refactored into a pure helper later,
+// import that helper directly. For now, we assert the sequence by
+// hand-rolling the same dispatch logic — this is a known duplication
+// acceptable for testing until the helper is extracted.
+
+describe('2-step generation event sequence', () => {
+  it.skip('pending extraction of parse dispatch into a pure helper', () => {
+    // Placeholder: extraction of the parse-dispatch logic from runOneShot
+    // into a testable pure function is a follow-up. For now, the bridge
+    // code is exercised by the existing stream-parser tests plus manual
+    // verification from the implementation plan's Phase 7 manual checklist.
+    expect(true).toBe(true);
+  });
+});
+```
+
+Note: a thorough unit test of runOneShot's emission sequence would require extracting the `parse` callback body into a pure function. That's a worthwhile refactor but deferred to avoid scope creep. The manual test checklist in Phase 7 covers this end-to-end.
+
+### Task 4.10: Commit Phase 4
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add scripts/server/claude-bridge.ts scripts/server/handlers/generate.ts scripts/__tests__/unit/generation-events.test.ts
+git commit -m "$(cat <<'EOF'
+feat(bridge): emit generation_stage, preview_reload, reference_preview
+
+The generate handler now emits a reference_preview event (for reference
+paths) and an initial generation_stage before runOneShot starts. Inside
+runOneShot, a tool_use counter drives generation_stage transitions
+(reading_reference → foundation → interactions), and each successful
+Write/Edit tool_result fires either preview_reload (if app.jsx parses)
+or preview_reload_failed (if it doesn't). The complete event gains an
+appJsxValid field for final validity.
+
+No UI consumer yet — unknown events are ignored by the current editor
+and the server-side signal is immediately useful for logs/telemetry.
+Phase 6 wires the editor UI.
+EOF
+)"
+```
+
+---
+
+## Phase 5 — `/reference-frame` route
+
+**Commit boundary at end of phase.** Serves the reference asset; consumed by UI in Phase 6.
+
+### Task 5.1: Write tests for the reference-frame handler
+
+**Files:**
+- Create: `scripts/__tests__/unit/reference-frame.test.ts`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+/**
+ * Tests for the /reference-frame route handler.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { serveReferenceFrame } from '../../server/handlers/reference-frame.ts';
+
+const TMP = join(import.meta.dirname, '.tmp-refframe-test');
+
+function makeCtx() {
+  return { projectRoot: TMP } as any;
+}
+
+beforeEach(() => {
+  mkdirSync(join(TMP, '.vibes-tmp'), { recursive: true });
+});
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe('serveReferenceFrame', () => {
+  it('serves an HTML reference as-is with text/html content-type', async () => {
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.html'), '<p>hi</p>');
+    const url = new URL('http://localhost/reference-frame?name=ref.html&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<p>hi</p>');
+  });
+
+  it('wraps an image reference in a full-bleed HTML shell', async () => {
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.png'), 'fake-png-bytes');
+    const url = new URL('http://localhost/reference-frame?name=ref.png&kind=image');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<img');
+    expect(body).toContain('src="/reference-frame?name=ref.png&kind=raw"');
+    expect(body).toContain('object-fit:contain');
+  });
+
+  it('returns the raw image bytes when kind=raw', async () => {
+    const bytes = Buffer.from([137, 80, 78, 71]); // PNG magic
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.png'), bytes);
+    const url = new URL('http://localhost/reference-frame?name=ref.png&kind=raw');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('image/');
+  });
+
+  it('rejects path traversal attempts', () => {
+    const url = new URL('http://localhost/reference-frame?name=..%2Fetc%2Fpasswd&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing name', () => {
+    const url = new URL('http://localhost/reference-frame?kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for a name that does not exist on disk', () => {
+    const url = new URL('http://localhost/reference-frame?name=nonexistent.html&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `cd scripts && npm run test:unit -- reference-frame`
+Expected: FAIL — handler not found.
+
+### Task 5.2: Implement the reference-frame handler
+
+**Files:**
+- Create: `scripts/server/handlers/reference-frame.ts`
+
+- [ ] **Step 1: Create the handler**
+
+```typescript
+/**
+ * GET /reference-frame — serve the user-uploaded reference asset inside
+ * an iframe-friendly wrapper so the preview iframe can show it while
+ * Claude is analyzing it in Step 1 of generation.
+ *
+ * Supported kinds:
+ *   - html: serve the file as-is with text/html (for HTML references)
+ *   - image: wrap the image in a minimal full-bleed HTML shell
+ *   - raw: return the raw file bytes (used by the image shell's <img src>)
+ *
+ * Security: the `name` query parameter is validated to be a plain filename
+ * (no slashes, no ..). The file is looked up only under the known reference
+ * directory (.vibes-tmp/) relative to projectRoot.
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join, extname } from 'path';
+import type { ServerContext } from '../config.ts';
+
+function corsHeaders(): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': `http://localhost:3333`,
+    'Vary': 'Origin',
+  };
+}
+
+function isSafeName(name: string): boolean {
+  return !!name && !name.includes('/') && !name.includes('\\') && !name.includes('..') && name.length <= 200;
+}
+
+function contentTypeFor(name: string): string {
+  const ext = extname(name).toLowerCase();
+  switch (ext) {
+    case '.png': return 'image/png';
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg';
+    case '.gif': return 'image/gif';
+    case '.webp': return 'image/webp';
+    case '.svg': return 'image/svg+xml';
+    case '.ico': return 'image/x-icon';
+    case '.avif': return 'image/avif';
+    default: return 'application/octet-stream';
+  }
+}
+
+export function serveReferenceFrame(ctx: ServerContext, url: URL): Response {
+  const name = url.searchParams.get('name') || '';
+  const kind = url.searchParams.get('kind') || '';
+
+  if (!isSafeName(name)) {
+    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+  }
+
+  const refDir = join(ctx.projectRoot, '.vibes-tmp');
+  const filePath = join(refDir, name);
+  if (!filePath.startsWith(refDir + '/')) {
+    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+  }
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+    return new Response('Not Found', { status: 404, headers: corsHeaders() });
+  }
+
+  if (kind === 'html') {
+    const body = readFileSync(filePath, 'utf-8');
+    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+  }
+
+  if (kind === 'raw') {
+    const bytes = readFileSync(filePath);
+    return new Response(bytes, { headers: { 'Content-Type': contentTypeFor(name), ...corsHeaders() } });
+  }
+
+  // kind === 'image' (or default): wrap in a minimal full-bleed shell
+  const rawSrc = `/reference-frame?name=${encodeURIComponent(name)}&kind=raw`;
+  const shell = `<!DOCTYPE html>
+<html><head>
+  <meta charset="utf-8">
+  <style>
+    html,body { margin:0; padding:0; height:100%; background:#000; }
+    img { display:block; width:100%; height:100%; object-fit:contain; }
+  </style>
+</head>
+<body><img src="${rawSrc}" alt="reference"></body></html>`;
+  return new Response(shell, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd scripts && npm run test:unit -- reference-frame`
+Expected: all 6 tests PASS.
+
+### Task 5.3: Register the route in router.ts
+
+**Files:**
+- Modify: `scripts/server/router.ts`
+
+- [ ] **Step 1: Add the import**
+
+Find the existing handler imports near the top (around line 15):
+
+```typescript
+import { assembleAppFrame } from './handlers/generate.ts';
+```
+
+Add after it:
+
+```typescript
+import { serveReferenceFrame } from './handlers/reference-frame.ts';
+```
+
+- [ ] **Step 2: Register the route**
+
+Find the route switch (around line 868):
+
+```typescript
+      case 'GET /app-frame':                return serveAppFrame(ctx, url);
+```
+
+Add a line right after it:
+
+```typescript
+      case 'GET /app-frame':                return serveAppFrame(ctx, url);
+      case 'GET /reference-frame':          return serveReferenceFrame(ctx, url);
+```
+
+### Task 5.4: Commit Phase 5
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add scripts/server/handlers/reference-frame.ts scripts/server/router.ts scripts/__tests__/unit/reference-frame.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server): add /reference-frame route for live reference preview
+
+New GET /reference-frame route serves the user-uploaded reference asset
+(image or HTML) inside an iframe-friendly wrapper. Consumed by the editor
+UI (next phase) to show the reference while Claude is analyzing it in
+Step 1 of generation.
+
+Security: name param must be a plain filename; lookup is scoped to the
+.vibes-tmp/ directory under projectRoot.
+EOF
+)"
+```
+
+---
+
+## Phase 6 — Editor UI
+
+**Commit boundary at end of phase.** UI consumes the events; full UX lands.
+
+Implementation note: the editor is a single-file template at `skills/vibes/templates/editor.html`. The WebSocket `onmessage` handler is around line 4205. The preview iframe has `id="previewFrame"` at line 3175. All edits in this phase are to that file.
+
+### Task 6.1: Add the overlay DOM
+
+**Files:**
+- Modify: `skills/vibes/templates/editor.html`
+
+- [ ] **Step 1: Find the preview iframe markup**
+
+Search for `id="previewFrame"` (line 3175-ish). The surrounding markup looks roughly like:
+
+```html
+<iframe class="preview-iframe" id="previewFrame" src="about:blank"></iframe>
+```
+
+- [ ] **Step 2: Wrap it in a positioned container and add the overlay**
+
+Replace the iframe line with:
+
+```html
+<div class="preview-container" id="previewContainer" style="position:relative; width:100%; height:100%;">
+  <iframe class="preview-iframe" id="previewFrame" src="about:blank"></iframe>
+  <div class="preview-overlay" id="previewOverlay" hidden>
+    <div class="preview-overlay-card" id="previewOverlayCard">
+      <div class="preview-overlay-spinner"></div>
+      <div class="preview-overlay-text" id="previewOverlayText">Starting...</div>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Add overlay CSS in the existing `<style>` block**
+
+Find the CSS block (the file has one large `<style>` near the top — search for `.preview-iframe {`). Add after it:
+
+```css
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 10, 10, 0.55);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto; /* absorb clicks on the skeleton */
+  z-index: 10;
+  transition: opacity 120ms ease;
+}
+.preview-overlay[hidden] { display: none; }
+.preview-overlay-card {
+  background: rgba(24, 24, 28, 0.9);
+  color: #eaeaea;
+  padding: 14px 20px;
+  border-radius: 10px;
+  font: 500 13px/1.4 system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+}
+.preview-overlay-card.error { background: rgba(80, 30, 30, 0.92); }
+.preview-overlay-spinner {
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,0.25);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: preview-overlay-spin 0.8s linear infinite;
+}
+.preview-overlay-card.error .preview-overlay-spinner { display: none; }
+@keyframes preview-overlay-spin { to { transform: rotate(360deg); } }
+```
+
+### Task 6.2: Add overlay state + helpers in the editor JS
+
+**Files:**
+- Modify: `skills/vibes/templates/editor.html`
+
+- [ ] **Step 1: Find a sensible place to add the helper functions**
+
+Search for `ws.onmessage = (event) =>` (around line 4205). Add the following helper block immediately before it:
+
+```javascript
+// --- Generation overlay state ---
+const OVERLAY_COPY = {
+  reading_reference: 'Analyzing reference — extracting design...',
+  foundation: 'Step 1 of 2 — Foundation',
+  interactions: 'Step 2 of 2 — Building interactions and polish',
+  preview_reload_failed_foundation: 'Step 1 produced a syntax error — waiting for retry...',
+  preview_reload_failed_interactions: 'Step 2 produced a syntax error — continuing...',
+};
+
+let overlayCurrentStage = null;
+let overlayInError = false;
+
+function setOverlayVisible(visible) {
+  const o = document.getElementById('previewOverlay');
+  if (!o) return;
+  if (visible) { o.hidden = false; } else { o.hidden = true; }
+}
+
+function setOverlayText(text, isError) {
+  const t = document.getElementById('previewOverlayText');
+  const card = document.getElementById('previewOverlayCard');
+  if (t) t.textContent = text;
+  if (card) card.classList.toggle('error', !!isError);
+}
+
+function handleGenerationStage(stage) {
+  overlayCurrentStage = stage;
+  if (overlayInError && stage === 'interactions') {
+    // Recovery: a new stage event clears the error state
+    overlayInError = false;
+  }
+  if (!overlayInError) {
+    setOverlayText(OVERLAY_COPY[stage] || stage, false);
+    setOverlayVisible(true);
+  }
+}
+
+function handlePreviewReload() {
+  // Cache-bust the preview iframe. If we were showing the reference asset,
+  // this is also the cue to swap back to /app-frame. Reuse the exact
+  // appParam derivation pattern used elsewhere in this file (see the existing
+  // reload call site around line 5066) — currentProjectDir is a full path,
+  // not an app name, so we derive `name` from it.
+  const frame = document.getElementById('previewFrame');
+  if (!frame) return;
+  if (overlayInError) overlayInError = false; // recovery: successful reload clears error
+  const name = currentProjectDir ? currentProjectDir.split('/').pop() : currentAppName;
+  const appParam = name ? 'app=' + encodeURIComponent(name) + '&' : '';
+  frame.src = '/app-frame?' + appParam + 't=' + Date.now();
+  // After a successful reload, restore the normal overlay copy for the current stage
+  if (overlayCurrentStage) setOverlayText(OVERLAY_COPY[overlayCurrentStage] || overlayCurrentStage, false);
+}
+
+function handlePreviewReloadFailed(stage) {
+  overlayInError = true;
+  const key = 'preview_reload_failed_' + stage;
+  setOverlayText(OVERLAY_COPY[key] || 'Syntax error — continuing...', true);
+}
+
+function handleReferencePreview(src) {
+  const frame = document.getElementById('previewFrame');
+  if (!frame) return;
+  frame.src = src;
+}
+
+function handleGenerationComplete(appJsxValid) {
+  setOverlayVisible(false);
+  overlayCurrentStage = null;
+  overlayInError = false;
+  if (appJsxValid === false) {
+    // Surface a persistent error chip / toast — project-specific UI hook.
+    // For now, just log; a later polish pass can attach to the existing toast system.
+    console.warn('[generate] app.jsx did not pass final validation');
+  }
+}
+```
+
+Note: references to `currentProjectDir` match the existing editor — it's the module-level variable used elsewhere (e.g., the existing `frame.src = '/app-frame?' + appParam + 't=' + Date.now()` pattern at lines 5068/5092). If naming differs slightly in this file, use the same variable that those existing reload sites use.
+
+### Task 6.3: Wire the new events into the WebSocket handler
+
+**Files:**
+- Modify: `skills/vibes/templates/editor.html`
+
+- [ ] **Step 1: Find the `ws.onmessage` handler**
+
+Search for `ws.onmessage = (event) =>` (~line 4205). Immediately inside its body, after the JSON parse and logging, add the new event dispatches. The existing handler starts like:
+
+```javascript
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type !== 'token') console.log('[WS-IN]', msg.type, ...);
+  // ... existing branches for 'complete', 'token', 'tool_result', etc.
+```
+
+Add a new early dispatch block right after the console.log and before the first existing `if`/`else if`:
+
+```javascript
+  // --- Direction D multi-turn generation events ---
+  if (msg.type === 'generation_stage') {
+    handleGenerationStage(msg.stage);
+    return;
+  }
+  if (msg.type === 'preview_reload') {
+    handlePreviewReload();
+    return;
+  }
+  if (msg.type === 'preview_reload_failed') {
+    handlePreviewReloadFailed(msg.stage);
+    return;
+  }
+  if (msg.type === 'reference_preview') {
+    handleReferencePreview(msg.src);
+    return;
+  }
+```
+
+- [ ] **Step 2: Hook the existing `complete` branch to dismiss the overlay**
+
+Find the existing `if (msg.type === 'complete')` branch in the same handler (around line 4212 or 4269). At the top of that branch, add:
+
+```javascript
+  if (msg.type === 'complete') {
+    handleGenerationComplete(msg.appJsxValid);
+    // ... existing complete logic continues below
+```
+
+Do not remove any existing logic in the complete branch.
+
+### Task 6.4: Manual smoke test
+
+- [ ] **Step 1: Start the server**
+
+```bash
+cd /Users/marcusestes/Websites/VibesCLI/VibesOS
+VIBES_ROOT="${CLAUDE_PLUGIN_ROOT:-$(pwd)}"
+bun "$VIBES_ROOT/scripts/server.ts" --mode=editor &
+```
+
+Expected: server listens on localhost:3333.
+
+- [ ] **Step 2: Generate a non-reference app**
+
+Open the editor in a browser. Submit a prompt like "a simple todo list".
+
+Expected:
+- Overlay appears immediately with "Step 1 of 2 — Foundation"
+- After ~10-15s the iframe updates to show a skeleton (header, empty content area, theme colors visible)
+- Overlay changes to "Step 2 of 2 — Building interactions and polish"
+- Eventually the iframe updates to the complete app
+- Overlay dismisses
+
+- [ ] **Step 3: Generate an image-reference app**
+
+Upload an image and submit a prompt like "an app with this vibe".
+
+Expected:
+- Overlay: "Analyzing reference — extracting design..."
+- Iframe shows the uploaded image (full-bleed, black background)
+- Overlay: "Step 1 of 2 — Foundation"
+- Iframe swaps to the skeleton
+- Overlay: "Step 2 of 2 — Building interactions and polish"
+- Iframe updates to complete app
+- Overlay dismisses
+
+- [ ] **Step 4: Verify the overlay absorbs clicks on the skeleton**
+
+Between Step 1 and Step 2 completion, click on the preview iframe. The overlay should absorb the clicks — nothing inside the iframe responds.
+
+- [ ] **Step 5: Stop the server**
+
+Bring the backgrounded `server.ts` to the foreground and Ctrl-C, or find the process and terminate it.
+
+### Task 6.5: Commit Phase 6
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add skills/vibes/templates/editor.html
+git commit -m "$(cat <<'EOF'
+feat(editor): wire multi-turn generation UI — staged preview + overlay
+
+Adds an overlay to the preview iframe that communicates generation
+progress (Analyzing reference / Step 1 / Step 2) and absorbs clicks so
+users can't interact with a partially-wired skeleton. Handles four new
+bridge events: generation_stage (overlay copy), preview_reload (iframe
+cache-bust), preview_reload_failed (non-fatal error state), and
+reference_preview (swap iframe src to reference asset).
+
+On complete, the overlay dismisses; if appJsxValid is false, the final
+state is a warning log (full toast integration is a future polish).
+EOF
+)"
+```
+
+---
+
+## Phase 7 — Version bump + final verification
+
+**Final commit boundary.**
+
+### Task 7.1: Bump plugin version
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Read the current version from plugin.json**
+
+```bash
+grep '"version"' /Users/marcusestes/Websites/VibesCLI/VibesOS/.claude-plugin/plugin.json
+```
+
+Expected: shows `"version": "0.2.15"` or similar.
+
+- [ ] **Step 2: Update plugin.json to 0.3.0**
+
+Edit the file and change the `version` field to `"0.3.0"`. Keep the rest untouched.
+
+- [ ] **Step 3: Update marketplace.json to 0.3.0**
+
+In `.claude-plugin/marketplace.json`, update the top-level `"version"` field (or the plugin entry's version field — follow whatever the existing file structure is) to `"0.3.0"`.
+
+- [ ] **Step 4: Verify with grep**
+
+```bash
+grep '"version"' /Users/marcusestes/Websites/VibesCLI/VibesOS/.claude-plugin/plugin.json /Users/marcusestes/Websites/VibesCLI/VibesOS/.claude-plugin/marketplace.json
+```
+
+Expected: both show `0.3.0`.
+
+### Task 7.2: Run the full test suite
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+cd /Users/marcusestes/Websites/VibesCLI/VibesOS/scripts && npm test
+```
+
+Expected: all unit tests pass, including the new `prompt-builders` DRY assertions, `validate-app-jsx` suite, and `reference-frame` suite. No regressions in the existing 694 tests.
+
+### Task 7.3: Run the E2E test
+
+- [ ] **Step 1: Run the vibes E2E test**
+
+This invokes the `/vibes:test` skill, which assembles a fixture and deploys to Cloudflare.
+
+Expected: the test passes and presents a live URL.
+
+### Task 7.4: Manual verification checklist
+
+Per the spec, run through these manual checks:
+
+- [ ] **Non-reference simple app** — prompt: "a todo list with categories". Watch preview update twice, verify overlay copy advances correctly.
+- [ ] **Image-reference, intent=match** — upload a distinctive image. Verify reference shows first, then skeleton, then complete app. Verify the generated app's colors match the image.
+- [ ] **HTML-reference** — upload a small HTML file with inline CSS. Same three-phase reveal.
+- [ ] **Text-reference, intent=seed** — upload a small CSV. Verify seeding logic ends up in Step 2's Edit (check app.jsx after generation).
+- [ ] **Force a syntax error** — temporarily modify the prompt to include `Deliberately emit a typo like "function App)" in step 1 to test error handling`. Re-run generation. Verify `preview_reload_failed` triggers the error overlay copy. Recovery not strictly testable without further contrivance; confirm the overlay state at least flashes correctly. Revert the contrived prompt after.
+- [ ] **Compliance check** — in server logs, grep for `preview_reload` events. For each generation you ran, count how many preview_reload events fired. Target: ≥2 per generation. Record the count in your notes.
+
+### Task 7.5: Commit Phase 7
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "$(cat <<'EOF'
+chore: bump to 0.3.0 for Direction D multi-turn generation
+
+Generation now uses a two-step prompt (Write skeleton → Edit rest) with
+live staged preview UX. See docs/plans/2026-04-23-direction-d-multi-turn-
+generation-design.md for the design; PR #68 shipped the companion
+max_tokens floor and instrumentation.
+EOF
+)"
+```
+
+### Task 7.6: Push and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(generate): 2-step app generation with live staged preview" --body "$(cat <<'EOF'
+## Summary
+
+Implements Direction D from the [design spec](docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md): Vibes OS app generation is now split into two Claude tool calls (Write skeleton → Edit rest) using Claude Code's native tool loop, which gives each step its own fresh max_tokens budget. Along the way, the preview iframe updates in stages — reference asset → skeleton → complete — with an overlay communicating progress.
+
+- **Prompt rewrite** — new TWO_STEP_INSTRUCTIONS and GLOBAL_STEP_RULES constants shared between reference and non-reference paths; regression test guards DRY.
+- **Config** — tools allowlist Write,Edit,Read on all generate paths; max-turns raised to 10/10/12.
+- **JSX validator** — Bun.Transpiler parse-check gates preview_reload emission.
+- **Bridge events** — new generation_stage, preview_reload, preview_reload_failed, reference_preview events; appJsxValid field on complete.
+- **Server route** — new /reference-frame serves the reference asset for the iframe preview.
+- **Editor UI** — overlay over the preview iframe, iframe src swap + cache-bust wired to new events.
+- **Version** — bumped to 0.3.0.
+
+## Test plan
+
+- [x] All unit tests pass (`cd scripts && npm test`)
+- [ ] E2E (`/vibes:test`) passes
+- [ ] Manual: non-reference, HTML-ref, image-ref, text-ref seed — each shows the intended staged preview reveal
+- [ ] Manual: overlay absorbs clicks on skeleton
+- [ ] Manual: syntax error produces preview_reload_failed overlay state
+- [ ] Log compliance check: ≥2 preview_reload events per generation in typical use
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (plan writer only, not part of execution)
+
+Before handing off, the plan writer should verify:
+
+1. **Spec coverage.** Every section of the design spec maps to a task:
+   - Turn structure → Tasks 1.4, 1.5
+   - Prompt rewrite + DRY → Tasks 1.1 through 1.6
+   - Bridge + UI plumbing → Phases 4 and 6
+   - Config changes → Phase 2
+   - Reference-path compatibility → Tasks 4.7, 5.1–5.4, 6.4
+   - Rollout + success metrics → Task 7.4 covers manual verification; compliance logging is in Task 7.4's final item
+2. **Placeholder scan.** The plan uses code blocks in every code-step. Task 4.9 contains a deliberately-skipped test (pending an acceptable follow-up refactor); that's called out explicitly, not a hidden TODO.
+3. **Type consistency.** Event names (`generation_stage`, `preview_reload`, `preview_reload_failed`, `reference_preview`) and the `appJsxValid` field are consistent across bridge emission, UI consumption, and the spec. Stage values (`reading_reference`, `foundation`, `interactions`) match in all three files.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/scripts/__tests__/unit/generation-events.test.ts
+++ b/scripts/__tests__/unit/generation-events.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Verify that runOneShot's stream parser emits the right sequence of
+ * generation_stage and preview_reload events given synthetic stream-json
+ * input for a 2-step generation.
+ */
+import { describe, it, expect } from 'vitest';
+
+describe('2-step generation event sequence', () => {
+  it.skip('pending extraction of parse dispatch into a pure helper', () => {
+    // Placeholder: extraction of the parse-dispatch logic from runOneShot
+    // into a testable pure function is a follow-up. For now, the bridge
+    // code is exercised by the existing stream-parser tests plus manual
+    // verification from the plan's Phase 7 manual checklist.
+    expect(true).toBe(true);
+  });
+});

--- a/scripts/__tests__/unit/generation-events.test.ts
+++ b/scripts/__tests__/unit/generation-events.test.ts
@@ -1,16 +1,367 @@
 /**
- * Verify that runOneShot's stream parser emits the right sequence of
- * generation_stage and preview_reload events given synthetic stream-json
- * input for a 2-step generation.
+ * Verify that `dispatchStreamEvent` emits the right sequence of
+ * generation_stage, tool_detail, tool_result, preview_reload, and
+ * preview_reload_failed events given synthetic stream-json input.
+ *
+ * This exercises the pure dispatcher lifted out of `runOneShot` — no
+ * subprocess spawning, no real stdout piping. A spy `onEvent` captures
+ * emissions and stub helpers supply deterministic elapsed / progress.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  createOneShotRunState,
+  dispatchStreamEvent,
+  type OneShotRunState,
+  type DispatchHelpers,
+} from '../../server/claude-bridge.ts';
 
-describe('2-step generation event sequence', () => {
-  it.skip('pending extraction of parse dispatch into a pure helper', () => {
-    // Placeholder: extraction of the parse-dispatch logic from runOneShot
-    // into a testable pure function is a follow-up. For now, the bridge
-    // code is exercised by the existing stream-parser tests plus manual
-    // verification from the plan's Phase 7 manual checklist.
-    expect(true).toBe(true);
+// --- test harness --------------------------------------------------------
+
+/** Captures every event emitted by the dispatcher. */
+function makeSpy() {
+  const events: any[] = [];
+  const onEvent = (e: any) => events.push(e);
+  return { events, onEvent };
+}
+
+/** Deterministic helpers — fixed elapsed, fixed progress. */
+function stubHelpers(overrides: Partial<DispatchHelpers> = {}): DispatchHelpers {
+  return {
+    getElapsed: () => 1,
+    calcProgress: (s: OneShotRunState) => {
+      // Ratchet the floor the way the real helper does, so tests that look
+      // at multiple progress events see non-decreasing values if they care.
+      s.baseProgress = Math.max(s.baseProgress, 50);
+      return { progress: s.baseProgress, stage: 'Reading & analyzing...' };
+    },
+    ...overrides,
+  };
+}
+
+/** Build a synthetic assistant message with a single tool_use block. */
+function assistantToolUse(opts: {
+  name: string;
+  id: string;
+  filePath?: string;
+  stop_reason?: string;
+}) {
+  return {
+    type: 'assistant',
+    message: {
+      stop_reason: opts.stop_reason,
+      content: [
+        {
+          type: 'tool_use',
+          id: opts.id,
+          name: opts.name,
+          input: opts.filePath ? { file_path: opts.filePath } : {},
+        },
+      ],
+    },
+  };
+}
+
+/** Build a synthetic tool_result event. */
+function toolResult(opts: { tool_use_id: string; tool_name: string; is_error?: boolean; content?: string }) {
+  return {
+    type: 'tool_result',
+    tool_use_id: opts.tool_use_id,
+    tool_name: opts.tool_name,
+    content: opts.content ?? 'ok',
+    is_error: !!opts.is_error,
+  };
+}
+
+// --- fixtures for the real validator -------------------------------------
+
+let tmpDir: string;
+let validAppPath: string;
+let brokenAppPath: string;
+let nonAppPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'genevents-'));
+  validAppPath = join(tmpDir, 'app.jsx');
+  brokenAppPath = join(tmpDir, 'app.jsx'); // tests overwrite this when they want it broken
+  nonAppPath = join(tmpDir, 'other.tsx');
+  writeFileSync(validAppPath, 'export default function App() { return <div>ok</div>; }\n');
+  writeFileSync(nonAppPath, 'export default function Other() { return <div>no-reload</div>; }\n');
+});
+
+// --- tests ---------------------------------------------------------------
+
+describe('dispatchStreamEvent — non-reference happy path', () => {
+  it('emits tool_detail + progress per Write/Edit and generation_stage only on the 2nd tool_use', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    const { events, onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    // 1st Write — since initialStage is already 'foundation', toolUseSeen === 1
+    // does NOT fire generation_stage (that's only for the reading_reference->foundation transition).
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 't1', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(
+      toolResult({ tool_use_id: 't1', tool_name: 'Write' }),
+      state,
+      onEvent,
+      helpers,
+    );
+
+    // 2nd Edit — toolUseSeen === 2, fires generation_stage: interactions.
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Edit', id: 't2', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(
+      toolResult({ tool_use_id: 't2', tool_name: 'Edit' }),
+      state,
+      onEvent,
+      helpers,
+    );
+
+    dispatchStreamEvent({ type: 'result', is_error: false, result: 'All done.' }, state, onEvent, helpers);
+
+    // Extract just the event type sequence for readability.
+    const types = events.map((e) => e.type);
+
+    // 1st Write: tool_detail, progress, tool_result, preview_reload
+    // 2nd Edit: generation_stage (interactions), tool_detail, progress, tool_result, preview_reload
+    expect(types).toEqual([
+      'tool_detail',
+      'progress',
+      'tool_result',
+      'preview_reload',
+      'generation_stage',
+      'tool_detail',
+      'progress',
+      'tool_result',
+      'preview_reload',
+    ]);
+
+    // generation_stage fires ONCE, and its value is 'interactions'.
+    const stageEvents = events.filter((e) => e.type === 'generation_stage');
+    expect(stageEvents).toEqual([{ type: 'generation_stage', stage: 'interactions' }]);
+
+    // State reflects the run.
+    expect(state.toolsUsed).toBe(2);
+    expect(state.hasEdited).toBe(true);
+    expect(state.toolUseSeen).toBe(2);
+    expect(state.currentStage).toBe('interactions');
+    expect(state.resultText).toBe('All done.');
+    expect(state.pendingTools.size).toBe(0);
   });
+});
+
+describe('dispatchStreamEvent — reference path happy path', () => {
+  it('emits foundation on 1st Write, interactions on 2nd, and Read does not advance the stage', () => {
+    const state = createOneShotRunState({ initialStage: 'reading_reference' });
+    const { events, onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    // A Read — should NOT advance the stage.
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Read', id: 'r1', filePath: '/some/reference.html' }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'r1', tool_name: 'Read' }), state, onEvent, helpers);
+    expect(state.currentStage).toBe('reading_reference');
+    expect(state.toolUseSeen).toBe(0);
+
+    // 1st Write — advances reading_reference -> foundation.
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 't1', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 't1', tool_name: 'Write' }), state, onEvent, helpers);
+
+    // 2nd Edit — advances to interactions.
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Edit', id: 't2', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 't2', tool_name: 'Edit' }), state, onEvent, helpers);
+
+    dispatchStreamEvent({ type: 'result', is_error: false, result: 'Done.' }, state, onEvent, helpers);
+
+    const stageEvents = events.filter((e) => e.type === 'generation_stage');
+    expect(stageEvents).toEqual([
+      { type: 'generation_stage', stage: 'foundation' },
+      { type: 'generation_stage', stage: 'interactions' },
+    ]);
+
+    expect(state.currentStage).toBe('interactions');
+    expect(state.toolUseSeen).toBe(2);
+    // Read still counted in toolsUsed (all tool_use blocks do).
+    expect(state.toolsUsed).toBe(3);
+  });
+});
+
+describe('dispatchStreamEvent — preview_reload gating', () => {
+  it('emits preview_reload only for successful Write/Edit to app.jsx', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    const { events, onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    // (1) Write to app.jsx, success -> preview_reload
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'a1', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'a1', tool_name: 'Write' }), state, onEvent, helpers);
+
+    // (2) Write to a non-app file -> NO preview_reload
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'a2', filePath: nonAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'a2', tool_name: 'Write' }), state, onEvent, helpers);
+
+    // (3) Write to app.jsx with is_error: true on the tool_result -> NO preview_reload
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'a3', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(
+      toolResult({ tool_use_id: 'a3', tool_name: 'Write', is_error: true, content: 'permission denied' }),
+      state,
+      onEvent,
+      helpers,
+    );
+
+    const reloads = events.filter((e) => e.type === 'preview_reload');
+    expect(reloads).toHaveLength(1);
+
+    const failed = events.filter((e) => e.type === 'preview_reload_failed');
+    expect(failed).toHaveLength(0);
+  });
+});
+
+describe('dispatchStreamEvent — preview_reload_failed on broken JSX', () => {
+  it('emits preview_reload_failed with the current stage when validateAppJsx fails', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    // After 1st Write, toolUseSeen becomes 1 (not 2), so currentStage stays 'foundation'.
+    const { events, onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    // Write broken JSX to the app path.
+    writeFileSync(brokenAppPath, 'export default function App() { return <div>oops; }\n');
+
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'b1', filePath: brokenAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'b1', tool_name: 'Write' }), state, onEvent, helpers);
+
+    const reloads = events.filter((e) => e.type === 'preview_reload');
+    const failed = events.filter((e) => e.type === 'preview_reload_failed');
+    expect(reloads).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].stage).toBe('foundation');
+    expect(typeof failed[0].error).toBe('string');
+    expect(failed[0].error.length).toBeGreaterThan(0);
+  });
+
+  it('reports stage: interactions once the dispatcher has transitioned past foundation', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    const { events, onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    // 1st Write (valid) — bumps toolUseSeen to 1.
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'i1', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'i1', tool_name: 'Write' }), state, onEvent, helpers);
+
+    // 2nd Edit — bumps toolUseSeen to 2, transitions state to 'interactions'.
+    // Now overwrite the file with broken JSX so the tool_result's validator fails.
+    writeFileSync(validAppPath, 'const broken = <div ');
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Edit', id: 'i2', filePath: validAppPath }),
+      state,
+      onEvent,
+      helpers,
+    );
+    dispatchStreamEvent(toolResult({ tool_use_id: 'i2', tool_name: 'Edit' }), state, onEvent, helpers);
+
+    const failed = events.filter((e) => e.type === 'preview_reload_failed');
+    expect(failed).toHaveLength(1);
+    expect(failed[0].stage).toBe('interactions');
+  });
+});
+
+describe('dispatchStreamEvent — max_tokens detection', () => {
+  it('sets state.hitMaxTokens when the assistant message stop_reason is max_tokens', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    const { onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    expect(state.hitMaxTokens).toBe(false);
+
+    dispatchStreamEvent(
+      assistantToolUse({
+        name: 'Write',
+        id: 'mx1',
+        filePath: validAppPath,
+        stop_reason: 'max_tokens',
+      }),
+      state,
+      onEvent,
+      helpers,
+    );
+
+    expect(state.hitMaxTokens).toBe(true);
+  });
+
+  it('leaves hitMaxTokens false for non-max_tokens stop_reasons', () => {
+    const state = createOneShotRunState({ initialStage: 'foundation' });
+    const { onEvent } = makeSpy();
+    const helpers = stubHelpers();
+
+    dispatchStreamEvent(
+      assistantToolUse({ name: 'Write', id: 'mx2', filePath: validAppPath, stop_reason: 'end_turn' }),
+      state,
+      onEvent,
+      helpers,
+    );
+
+    expect(state.hitMaxTokens).toBe(false);
+  });
+});
+
+// Ensure each temp dir is cleaned up so vitest's watch mode stays tidy.
+// (Vitest re-invokes beforeEach per test; cleanup below runs after all of them.)
+import { afterAll } from 'vitest';
+afterAll(() => {
+  // Best-effort; if a test already removed it, rmSync won't throw with force.
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
 });

--- a/scripts/__tests__/unit/prompt-builders.test.ts
+++ b/scripts/__tests__/unit/prompt-builders.test.ts
@@ -244,3 +244,31 @@ describe('extractDataSchema', () => {
     expect(extractDataSchema('')).toBe('');
   });
 });
+
+describe('buildGeneratePrompt shared constants (DRY refactor)', () => {
+  it('non-reference path contains TWO_STEP_INSTRUCTIONS and GLOBAL_STEP_RULES', () => {
+    writeFileSync(join(TMP, 'themes', 'abstract.txt'), ':root { --color-background: oklch(20% 0 0); }');
+    const ctx = makeCtx({
+      themes: [{ id: 'abstract', name: 'Abstract' }],
+      themeColors: { abstract: { bg: '#000', rootBlock: ':root { --color-background: oklch(20% 0 0); }' } },
+    });
+    const result = buildGeneratePrompt(ctx as any, 'a todo list', { themeId: 'abstract' });
+    expect(result.prompt).toContain('=== BUILD app.jsx IN TWO TOOL CALLS ===');
+    expect(result.prompt).toContain('STEP 1 — Write app.jsx');
+    expect(result.prompt).toContain('STEP 2 — Edit app.jsx');
+    expect(result.prompt).toContain('=== RULES THAT APPLY TO ALL STEPS ===');
+  });
+
+  it('reference path (HTML) contains the same TWO_STEP_INSTRUCTIONS and GLOBAL_STEP_RULES', () => {
+    const refPath = join(TMP, 'ref.html');
+    writeFileSync(refPath, '<html><body style="background:#f00">Hi</body></html>');
+    const ctx = makeCtx();
+    const result = buildGeneratePrompt(ctx as any, 'match this', {
+      reference: { name: 'ref.html', serverPath: refPath, intent: 'match' },
+    });
+    expect(result.prompt).toContain('=== BUILD app.jsx IN TWO TOOL CALLS ===');
+    expect(result.prompt).toContain('STEP 1 — Write app.jsx');
+    expect(result.prompt).toContain('STEP 2 — Edit app.jsx');
+    expect(result.prompt).toContain('=== RULES THAT APPLY TO ALL STEPS ===');
+  });
+});

--- a/scripts/__tests__/unit/prompt-builders.test.ts
+++ b/scripts/__tests__/unit/prompt-builders.test.ts
@@ -271,4 +271,63 @@ describe('buildGeneratePrompt shared constants (DRY refactor)', () => {
     expect(result.prompt).toContain('STEP 2 — Edit app.jsx');
     expect(result.prompt).toContain('=== RULES THAT APPLY TO ALL STEPS ===');
   });
+
+  it('both paths emit a single === DESIGN REASONING === section via the shared helper', () => {
+    writeFileSync(join(TMP, 'themes', 'abstract.txt'), ':root { --color-background: oklch(20% 0 0); }');
+    const ctx = makeCtx({
+      themes: [{ id: 'abstract', name: 'Abstract' }],
+      themeColors: { abstract: { bg: '#000', rootBlock: ':root { --color-background: oklch(20% 0 0); }' } },
+    });
+    const nonRef = buildGeneratePrompt(ctx as any, 'a todo list', { themeId: 'abstract' });
+    const refPath = join(TMP, 'ref.html');
+    writeFileSync(refPath, '<html><body>Hi</body></html>');
+    const ref = buildGeneratePrompt(makeCtx() as any, 'match this', {
+      reference: { name: 'ref.html', serverPath: refPath, intent: 'match' },
+    });
+
+    // Exactly one DESIGN REASONING section per path (no duplicated block)
+    const countMarker = (s: string) => (s.match(/=== DESIGN REASONING ===/g) || []).length;
+    expect(countMarker(nonRef.prompt)).toBe(1);
+    expect(countMarker(ref.prompt)).toBe(1);
+
+    // The CSS-comment framing from the shared helper is present in both
+    expect(nonRef.prompt).toContain('Briefly note design decisions inside CSS comments');
+    expect(ref.prompt).toContain('Briefly note design decisions inside CSS comments');
+
+    // Path-specific wording (differentiates the helper outputs)
+    expect(nonRef.prompt).toContain('"Abstract" personality shapes visual choices');
+    expect(nonRef.prompt).toContain('theme mood');
+    expect(ref.prompt).toContain('extracted from the reference');
+    expect(ref.prompt).toContain('reference mood');
+  });
+
+  it('GLOBAL_STEP_RULES does not duplicate bullets already in RECENCY_REMINDER', () => {
+    writeFileSync(join(TMP, 'themes', 'abstract.txt'), ':root {}');
+    const ctx = makeCtx({
+      themes: [{ id: 'abstract', name: 'Abstract' }],
+      themeColors: { abstract: { bg: '#000', rootBlock: ':root {}' } },
+    });
+    const result = buildGeneratePrompt(ctx as any, 'a todo list', { themeId: 'abstract' });
+    const prompt = result.prompt;
+
+    // Locate the GLOBAL_STEP_RULES section (from its header to the next === ... === marker)
+    const rulesStart = prompt.indexOf('=== RULES THAT APPLY TO ALL STEPS ===');
+    expect(rulesStart).toBeGreaterThan(-1);
+    const rulesTail = prompt.slice(rulesStart);
+    // The block ends at the next double-newline-followed-by-=== section, or the template tail
+    const nextSectionIdx = rulesTail.slice(1).search(/\n=== /);
+    const rulesBlock = nextSectionIdx >= 0 ? rulesTail.slice(0, nextSectionIdx + 1) : rulesTail;
+
+    // These RECENCY_REMINDER bullets must NOT be repeated inside the rules block
+    expect(rulesBlock).not.toContain('NO imports. NO createStore');
+    expect(rulesBlock).not.toContain('useApp() is mandatory in root App');
+    expect(rulesBlock).not.toContain('No sync/connection status UI');
+    expect(rulesBlock).not.toContain("Table names must be string literals: useRowIds('todos')");
+
+    // These GLOBAL_STEP_RULES-specific bullets MUST still be present
+    expect(rulesBlock).toContain('NO TypeScript');
+    expect(rulesBlock).toContain('CSS unicode escapes');
+    expect(rulesBlock).toContain('mobile-first with Tailwind');
+    expect(rulesBlock).toContain('useApp() returns { isReady, isSyncing, user }');
+  });
 });

--- a/scripts/__tests__/unit/reference-frame.test.ts
+++ b/scripts/__tests__/unit/reference-frame.test.ts
@@ -9,7 +9,7 @@ import { serveReferenceFrame } from '../../server/handlers/reference-frame.ts';
 const TMP = join(import.meta.dirname, '.tmp-refframe-test');
 
 function makeCtx() {
-  return { projectRoot: TMP } as any;
+  return { projectRoot: TMP, port: 3333 } as any;
 }
 
 beforeEach(() => {
@@ -67,5 +67,13 @@ describe('serveReferenceFrame', () => {
     const url = new URL('http://localhost/reference-frame?name=nonexistent.html&kind=html');
     const res = serveReferenceFrame(makeCtx(), url);
     expect(res.status).toBe(404);
+  });
+
+  it('uses the port from ctx for the CORS Access-Control-Allow-Origin header', () => {
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.html'), '<p>hi</p>');
+    const url = new URL('http://localhost/reference-frame?name=ref.html&kind=html');
+    const ctx = { projectRoot: TMP, port: 4444 } as any;
+    const res = serveReferenceFrame(ctx, url);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:4444');
   });
 });

--- a/scripts/__tests__/unit/reference-frame.test.ts
+++ b/scripts/__tests__/unit/reference-frame.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the /reference-frame route handler.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { serveReferenceFrame } from '../../server/handlers/reference-frame.ts';
+
+const TMP = join(import.meta.dirname, '.tmp-refframe-test');
+
+function makeCtx() {
+  return { projectRoot: TMP } as any;
+}
+
+beforeEach(() => {
+  mkdirSync(join(TMP, '.vibes-tmp'), { recursive: true });
+});
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe('serveReferenceFrame', () => {
+  it('serves an HTML reference as-is with text/html content-type', async () => {
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.html'), '<p>hi</p>');
+    const url = new URL('http://localhost/reference-frame?name=ref.html&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<p>hi</p>');
+  });
+
+  it('wraps an image reference in a full-bleed HTML shell', async () => {
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.png'), 'fake-png-bytes');
+    const url = new URL('http://localhost/reference-frame?name=ref.png&kind=image');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<img');
+    expect(body).toContain('src="/reference-frame?name=ref.png&kind=raw"');
+    expect(body).toContain('object-fit:contain');
+  });
+
+  it('returns the raw image bytes when kind=raw', async () => {
+    const bytes = Buffer.from([137, 80, 78, 71]); // PNG magic
+    writeFileSync(join(TMP, '.vibes-tmp', 'ref.png'), bytes);
+    const url = new URL('http://localhost/reference-frame?name=ref.png&kind=raw');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('image/');
+  });
+
+  it('rejects path traversal attempts', () => {
+    const url = new URL('http://localhost/reference-frame?name=..%2Fetc%2Fpasswd&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing name', () => {
+    const url = new URL('http://localhost/reference-frame?kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for a name that does not exist on disk', () => {
+    const url = new URL('http://localhost/reference-frame?name=nonexistent.html&kind=html');
+    const res = serveReferenceFrame(makeCtx(), url);
+    expect(res.status).toBe(404);
+  });
+});

--- a/scripts/__tests__/unit/validate-app-jsx.test.ts
+++ b/scripts/__tests__/unit/validate-app-jsx.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for validateAppJsx — parse-check app.jsx using Bun.Transpiler.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { validateAppJsx } from '../../lib/validate-app-jsx.ts';
+
+const TMP = join(import.meta.dirname, '.tmp-validate-test');
+
+beforeEach(() => { mkdirSync(TMP, { recursive: true }); });
+afterEach(() => { rmSync(TMP, { recursive: true, force: true }); });
+
+describe('validateAppJsx', () => {
+  it('returns ok for a minimal valid component', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'function App() { return <div>Hi</div>; }\nexport default App;');
+    expect(validateAppJsx(p)).toEqual({ ok: true });
+  });
+
+  it('returns ok for JSX that uses TinyBase-style globals (no imports)', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, `
+      function App() {
+        const ids = useRowIds('todos');
+        return <ul>{ids.map(id => <li key={id} />)}</ul>;
+      }
+      export default App;
+    `);
+    expect(validateAppJsx(p)).toEqual({ ok: true });
+  });
+
+  it('returns not-ok with error for unclosed JSX tag', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'function App() { return <div>Hi; }\nexport default App;');
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.length).toBeGreaterThan(0);
+  });
+
+  it('returns not-ok for unterminated template literal', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, 'const s = `hello world');
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+  });
+
+  it('truncates long error messages to 500 chars', () => {
+    const p = join(TMP, 'app.jsx');
+    writeFileSync(p, '(' .repeat(2000));
+    const r = validateAppJsx(p);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.length).toBeLessThanOrEqual(500);
+  });
+});

--- a/scripts/lib/validate-app-jsx.ts
+++ b/scripts/lib/validate-app-jsx.ts
@@ -1,0 +1,31 @@
+/**
+ * Parse-check app.jsx using esbuild's transform in JSX mode.
+ *
+ * Called from the generate flow after each successful Write/Edit tool_result
+ * to decide whether to emit preview_reload (file is parseable, iframe can
+ * safely refresh) or preview_reload_failed (last-known-good render should
+ * stay on screen).
+ *
+ * Note: this is a syntax-only check. It does not catch React runtime errors,
+ * missing globals, or broken prop shapes — the in-browser Babel load in the
+ * preview iframe is the final arbiter for those.
+ *
+ * Uses esbuild (already a dep) rather than Bun.Transpiler so the same code
+ * works under Node (tests) and Bun (runtime).
+ */
+
+import { readFileSync } from 'fs';
+import { transformSync } from 'esbuild';
+
+export type ValidateResult = { ok: true } | { ok: false; error: string };
+
+export function validateAppJsx(path: string): ValidateResult {
+  try {
+    const code = readFileSync(path, 'utf-8');
+    transformSync(code, { loader: 'jsx' });
+    return { ok: true };
+  } catch (e: any) {
+    const msg = String(e?.message ?? e);
+    return { ok: false, error: msg.slice(0, 500) };
+  }
+}

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -8,9 +8,11 @@
  * imports from this module continue to work.
  */
 
+import { basename } from 'path';
 import { createStreamParser } from '../lib/stream-parser.js';
 import { buildPersistentArgs, resolveClaudeBin, cleanEnv } from '../lib/claude-subprocess.js';
 import { translateStreamEvent } from './event-translator.ts';
+import { validateAppJsx } from '../lib/validate-app-jsx.ts';
 
 // --- Types ---
 
@@ -391,6 +393,10 @@ export interface OneShotOpts {
   permissionMode?: string;
   /** Operation type for the lock (default: 'chat'). Set to false to skip auto-locking. */
   lockType?: string | false;
+  /** Initial generation_stage, used by the tool_use counter to decide when
+   * to emit the foundation → interactions transition. Only passed by the
+   * generate handler; chat/theme paths leave it undefined. */
+  initialStage?: 'reading_reference' | 'foundation';
 }
 
 export async function runOneShot(
@@ -446,6 +452,8 @@ export async function runOneShot(
   let hasEdited = false;
   let errorSent = false;
   let hitMaxTokens = false;
+  let toolUseSeen = 0; // counts Write/Edit tool_use events; drives generation_stage transitions
+  let currentStage: 'reading_reference' | 'foundation' | 'interactions' | null = opts.initialStage ?? null;
   const startTime = Date.now();
   let lastStdoutTime = Date.now();
   let killedByTimeout = false;
@@ -522,6 +530,19 @@ export async function runOneShot(
             pendingTools.set(block.id, { name: toolName, filePath: inputSummary });
           }
 
+          // Advance the generation stage on Write/Edit boundaries. Read tool
+          // uses don't count — they're setup, not a step boundary.
+          if (toolName === 'Write' || toolName === 'Edit') {
+            toolUseSeen++;
+            if (toolUseSeen === 1 && currentStage === 'reading_reference') {
+              currentStage = 'foundation';
+              onEvent({ type: 'generation_stage', stage: 'foundation' });
+            } else if (toolUseSeen === 2) {
+              currentStage = 'interactions';
+              onEvent({ type: 'generation_stage', stage: 'interactions' });
+            }
+          }
+
           onEvent({ type: 'tool_detail', name: toolName, input_summary: inputSummary, elapsed });
           onEvent({ type: 'progress', ...calcProgressLocal(), elapsed });
         }
@@ -545,6 +566,24 @@ export async function runOneShot(
         _filePath: toolDetail?.filePath || '',
         _toolName: toolDetail?.name || event.tool_name || '',
       });
+
+      // After a successful Write/Edit to app.jsx, parse-check the file. If it
+      // parses, signal the UI to refresh the preview iframe. If it fails,
+      // surface the error without reloading — the last-known-good render stays.
+      const wasWriteOrEdit = toolDetail?.name === 'Write' || toolDetail?.name === 'Edit';
+      const targetedAppJsx = typeof toolDetail?.filePath === 'string' && basename(toolDetail.filePath) === 'app.jsx';
+      if (wasWriteOrEdit && targetedAppJsx && !event.is_error) {
+        const v = validateAppJsx(toolDetail!.filePath);
+        if (v.ok) {
+          onEvent({ type: 'preview_reload' });
+        } else {
+          onEvent({
+            type: 'preview_reload_failed',
+            stage: currentStage === 'interactions' ? 'interactions' : 'foundation',
+            error: v.error,
+          });
+        }
+      }
     } else if (event.type === 'result') {
       if (event.is_error) {
         const errMsg = event.result || 'Claude flagged the run as failed';
@@ -640,6 +679,16 @@ export async function runOneShot(
     sanitizeAppJsx(projectRoot);
   }
 
+  let appJsxValid: boolean | undefined = undefined;
+  if (hasEdited && opts.cwd) {
+    const appPath = `${opts.cwd}/app.jsx`;
+    try {
+      appJsxValid = validateAppJsx(appPath).ok;
+    } catch {
+      appJsxValid = false;
+    }
+  }
+
   if (!errorSent) {
     onEvent({
       type: 'complete',
@@ -649,6 +698,7 @@ export async function runOneShot(
       hasEdited,
       skipChat: opts.skipChat,
       maxTokensHit: hitMaxTokens,
+      appJsxValid,
     });
   }
 

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -399,6 +399,166 @@ export interface OneShotOpts {
   initialStage?: 'reading_reference' | 'foundation';
 }
 
+// --- One-Shot Dispatch (extracted for testability) ---
+
+/**
+ * Mutable state accumulated across stream events in a single runOneShot call.
+ * Every field the dispatcher reads or writes lives here — the dispatcher
+ * closes over NO locals, so it's fully unit-testable with a synthetic state
+ * object and a spy onEvent callback.
+ */
+export interface OneShotRunState {
+  toolsUsed: number;
+  hasEdited: boolean;
+  hitMaxTokens: boolean;
+  /** Count of Write/Edit tool_use events. Drives generation_stage transitions. */
+  toolUseSeen: number;
+  currentStage: 'reading_reference' | 'foundation' | 'interactions' | null;
+  resultText: string;
+  errorSent: boolean;
+  /** tool_use_id -> {name, filePath}. Populated on tool_use, consumed on tool_result. */
+  pendingTools: Map<string, { name: string; filePath: string }>;
+  /** Monotonic floor for progress %. `calcProgress` ratchets this so progress
+   * never rewinds within a run. */
+  baseProgress: number;
+}
+
+export function createOneShotRunState(opts: { initialStage?: 'reading_reference' | 'foundation' } = {}): OneShotRunState {
+  return {
+    toolsUsed: 0,
+    hasEdited: false,
+    hitMaxTokens: false,
+    toolUseSeen: 0,
+    currentStage: opts.initialStage ?? null,
+    resultText: '',
+    errorSent: false,
+    pendingTools: new Map(),
+    baseProgress: 0,
+  };
+}
+
+/**
+ * Wall-clock and validator hooks the dispatcher needs. Injected so tests can
+ * supply deterministic stubs (fixed elapsed, fixed progress, stubbed
+ * validateAppJsx).
+ */
+export interface DispatchHelpers {
+  getElapsed: () => number;
+  /** Should return the current { progress, stage }. Implementations are
+   * expected to ratchet state.baseProgress so progress never decreases. */
+  calcProgress: (state: OneShotRunState) => { progress: number; stage: string };
+  /** Parse-check a file. Returns { ok: true } on success, { ok: false, error }
+   * on failure. Defaults to the real `validateAppJsx` — tests pass a stub. */
+  validateAppJsx?: (path: string) => { ok: true } | { ok: false; error: string };
+  /** PID for diagnostic logging only (max_tokens warning). Optional — tests
+   * can omit it; runOneShot supplies the real subprocess pid. */
+  processPid?: number;
+}
+
+/**
+ * Consume one parsed stream-json event. Mutates `state` in place and emits
+ * UI events via `onEvent`. This is the inner body of runOneShot's stream
+ * parser callback, lifted out so it can be exercised by unit tests without
+ * spawning a subprocess.
+ *
+ * Behavior is identical to the pre-refactor inline callback — every read and
+ * write goes through `state.*` instead of closure locals, and wall-clock /
+ * validator access happens via `helpers`.
+ */
+export function dispatchStreamEvent(
+  event: any,
+  state: OneShotRunState,
+  onEvent: EventCallback,
+  helpers: DispatchHelpers,
+): void {
+  const elapsed = helpers.getElapsed();
+  const validate = helpers.validateAppJsx ?? validateAppJsx;
+
+  if (event.type === 'assistant' && event.message?.content) {
+    if (event.message.stop_reason === 'max_tokens') {
+      state.hitMaxTokens = true;
+      const pidLabel = helpers.processPid != null ? ` PID ${helpers.processPid}` : '';
+      console.warn(`[OneShot]${pidLabel} hit max_tokens at ${elapsed}s (tools=${state.toolsUsed}, hasEdited=${state.hasEdited})`);
+    }
+    for (const block of event.message.content) {
+      if (block.type === 'tool_use') {
+        state.toolsUsed++;
+        const toolName = block.name || '';
+        if (toolName === 'Edit' || toolName === 'Write') state.hasEdited = true;
+        const inputSummary = summarizeInput(block);
+
+        if (block.id) {
+          state.pendingTools.set(block.id, { name: toolName, filePath: inputSummary });
+        }
+
+        // Advance the generation stage on Write/Edit boundaries. Read tool
+        // uses don't count — they're setup, not a step boundary.
+        if (toolName === 'Write' || toolName === 'Edit') {
+          state.toolUseSeen++;
+          if (state.toolUseSeen === 1 && state.currentStage === 'reading_reference') {
+            state.currentStage = 'foundation';
+            onEvent({ type: 'generation_stage', stage: 'foundation' });
+          } else if (state.toolUseSeen === 2) {
+            state.currentStage = 'interactions';
+            onEvent({ type: 'generation_stage', stage: 'interactions' });
+          }
+        }
+
+        onEvent({ type: 'tool_detail', name: toolName, input_summary: inputSummary, elapsed });
+        onEvent({ type: 'progress', ...helpers.calcProgress(state), elapsed });
+      }
+      if (block.type === 'text' && block.text) {
+        state.resultText = block.text;
+        onEvent({ type: 'token', text: block.text });
+      }
+    }
+  } else if (event.type === 'stream_event' && event.event?.delta?.text) {
+    onEvent({ type: 'token', text: event.event.delta.text });
+  } else if (event.type === 'tool_result') {
+    const toolDetail = event.tool_use_id ? state.pendingTools.get(event.tool_use_id) : undefined;
+    if (event.tool_use_id) state.pendingTools.delete(event.tool_use_id);
+
+    onEvent({
+      type: 'tool_result',
+      name: event.tool_name || '',
+      content: (typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '')).slice(0, 500),
+      is_error: !!event.is_error,
+      elapsed,
+      _filePath: toolDetail?.filePath || '',
+      _toolName: toolDetail?.name || event.tool_name || '',
+    });
+
+    // After a successful Write/Edit to app.jsx, parse-check the file. If it
+    // parses, signal the UI to refresh the preview iframe. If it fails,
+    // surface the error without reloading — the last-known-good render stays.
+    const wasWriteOrEdit = toolDetail?.name === 'Write' || toolDetail?.name === 'Edit';
+    const targetedAppJsx = typeof toolDetail?.filePath === 'string' && basename(toolDetail.filePath) === 'app.jsx';
+    if (wasWriteOrEdit && targetedAppJsx && !event.is_error) {
+      const v = validate(toolDetail!.filePath);
+      if (v.ok) {
+        onEvent({ type: 'preview_reload' });
+      } else {
+        onEvent({
+          type: 'preview_reload_failed',
+          stage: state.currentStage === 'interactions' ? 'interactions' : 'foundation',
+          error: v.error,
+        });
+      }
+    }
+  } else if (event.type === 'result') {
+    if (event.is_error) {
+      const errMsg = event.result || 'Claude flagged the run as failed';
+      console.error(`[OneShot] Result is_error: ${errMsg}`);
+      onEvent({ type: 'error', message: errMsg });
+      state.errorSent = true;
+    } else {
+      state.resultText = event.result || state.resultText || 'Done.';
+    }
+  } else if (event.type === 'rate_limit_event') {
+    onEvent({ type: 'progress', ...helpers.calcProgress(state), stage: 'Rate limited, waiting...', elapsed });
+  }
+}
+
 export async function runOneShot(
   prompt: string,
   opts: OneShotOpts,
@@ -447,27 +607,18 @@ export async function runOneShot(
   }
 
   let stderrBuffer = '';
-  let resultText = '';
-  let toolsUsed = 0;
-  let hasEdited = false;
-  let errorSent = false;
-  let hitMaxTokens = false;
-  let toolUseSeen = 0; // counts Write/Edit tool_use events; drives generation_stage transitions
-  let currentStage: 'reading_reference' | 'foundation' | 'interactions' | null = opts.initialStage ?? null;
+  const runState = createOneShotRunState({ initialStage: opts.initialStage });
   const startTime = Date.now();
   let lastStdoutTime = Date.now();
   let killedByTimeout = false;
-  const pendingTools = new Map<string, { name: string; filePath: string }>();
 
   function getElapsed() {
     return Math.round((Date.now() - startTime) / 1000);
   }
 
-  let baseProgress = 0;
-
-  function calcProgressLocal(): { progress: number; stage: string } {
-    const result = calcProgressFromCounters(getElapsed(), toolsUsed, hasEdited, baseProgress);
-    baseProgress = result.progress; // ratchet: progress never decreases in one-shot
+  function calcProgressLocal(state: OneShotRunState = runState): { progress: number; stage: string } {
+    const result = calcProgressFromCounters(getElapsed(), state.toolsUsed, state.hasEdited, state.baseProgress);
+    state.baseProgress = result.progress; // ratchet: progress never decreases in one-shot
     return result;
   }
 
@@ -512,90 +663,11 @@ export async function runOneShot(
   // Read stdout with stream parser
   const parse = createStreamParser((event: any) => {
     lastStdoutTime = Date.now();
-    const elapsed = getElapsed();
-
-    if (event.type === 'assistant' && event.message?.content) {
-      if (event.message.stop_reason === 'max_tokens') {
-        hitMaxTokens = true;
-        console.warn(`[OneShot] PID ${proc.pid} hit max_tokens at ${getElapsed()}s (tools=${toolsUsed}, hasEdited=${hasEdited})`);
-      }
-      for (const block of event.message.content) {
-        if (block.type === 'tool_use') {
-          toolsUsed++;
-          const toolName = block.name || '';
-          if (toolName === 'Edit' || toolName === 'Write') hasEdited = true;
-          const inputSummary = summarizeInput(block);
-
-          if (block.id) {
-            pendingTools.set(block.id, { name: toolName, filePath: inputSummary });
-          }
-
-          // Advance the generation stage on Write/Edit boundaries. Read tool
-          // uses don't count — they're setup, not a step boundary.
-          if (toolName === 'Write' || toolName === 'Edit') {
-            toolUseSeen++;
-            if (toolUseSeen === 1 && currentStage === 'reading_reference') {
-              currentStage = 'foundation';
-              onEvent({ type: 'generation_stage', stage: 'foundation' });
-            } else if (toolUseSeen === 2) {
-              currentStage = 'interactions';
-              onEvent({ type: 'generation_stage', stage: 'interactions' });
-            }
-          }
-
-          onEvent({ type: 'tool_detail', name: toolName, input_summary: inputSummary, elapsed });
-          onEvent({ type: 'progress', ...calcProgressLocal(), elapsed });
-        }
-        if (block.type === 'text' && block.text) {
-          resultText = block.text;
-          onEvent({ type: 'token', text: block.text });
-        }
-      }
-    } else if (event.type === 'stream_event' && event.event?.delta?.text) {
-      onEvent({ type: 'token', text: event.event.delta.text });
-    } else if (event.type === 'tool_result') {
-      const toolDetail = event.tool_use_id ? pendingTools.get(event.tool_use_id) : undefined;
-      if (event.tool_use_id) pendingTools.delete(event.tool_use_id);
-
-      onEvent({
-        type: 'tool_result',
-        name: event.tool_name || '',
-        content: (typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '')).slice(0, 500),
-        is_error: !!event.is_error,
-        elapsed,
-        _filePath: toolDetail?.filePath || '',
-        _toolName: toolDetail?.name || event.tool_name || '',
-      });
-
-      // After a successful Write/Edit to app.jsx, parse-check the file. If it
-      // parses, signal the UI to refresh the preview iframe. If it fails,
-      // surface the error without reloading — the last-known-good render stays.
-      const wasWriteOrEdit = toolDetail?.name === 'Write' || toolDetail?.name === 'Edit';
-      const targetedAppJsx = typeof toolDetail?.filePath === 'string' && basename(toolDetail.filePath) === 'app.jsx';
-      if (wasWriteOrEdit && targetedAppJsx && !event.is_error) {
-        const v = validateAppJsx(toolDetail!.filePath);
-        if (v.ok) {
-          onEvent({ type: 'preview_reload' });
-        } else {
-          onEvent({
-            type: 'preview_reload_failed',
-            stage: currentStage === 'interactions' ? 'interactions' : 'foundation',
-            error: v.error,
-          });
-        }
-      }
-    } else if (event.type === 'result') {
-      if (event.is_error) {
-        const errMsg = event.result || 'Claude flagged the run as failed';
-        console.error(`[OneShot] Result is_error: ${errMsg}`);
-        onEvent({ type: 'error', message: errMsg });
-        errorSent = true;
-      } else {
-        resultText = event.result || resultText || 'Done.';
-      }
-    } else if (event.type === 'rate_limit_event') {
-      onEvent({ type: 'progress', ...calcProgressLocal(), stage: 'Rate limited, waiting...', elapsed });
-    }
+    dispatchStreamEvent(event, runState, onEvent, {
+      getElapsed,
+      calcProgress: calcProgressLocal,
+      processPid: proc.pid,
+    });
   });
 
   const stdoutReader = proc.stdout.getReader();
@@ -631,7 +703,7 @@ export async function runOneShot(
   // Release the operation lock now that the subprocess has exited.
   if (useLock) releaseLock();
 
-  console.log(`[OneShot] Completed in ${getElapsed()}s (${toolsUsed} tools, code ${exitCode})`);
+  console.log(`[OneShot] Completed in ${getElapsed()}s (${runState.toolsUsed} tools, code ${exitCode})`);
 
   // SIGTERM exit: process was cancelled via cancelCurrent()
   if (exitCode === 143 || exitCode === 137) {
@@ -640,7 +712,7 @@ export async function runOneShot(
     return null;
   }
 
-  if (killedByTimeout && !errorSent) {
+  if (killedByTimeout && !runState.errorSent) {
     onEvent({ type: 'error', message: `Claude stopped responding after ${getElapsed()}s. Try again.` });
     return null;
   }
@@ -648,9 +720,9 @@ export async function runOneShot(
   if (exitCode !== 0 && exitCode !== null) {
     const isMaxTurns = stderrBuffer.includes('max_turns') || stderrBuffer.includes('maxTurns');
     if (isMaxTurns) {
-      console.log(`[OneShot] Hit max_turns (hasEdited=${hasEdited}) — treating as success`);
-      resultText = (resultText || '') + '\n\n*[Ran out of turns — send another message to continue where I left off]*';
-    } else if (!errorSent) {
+      console.log(`[OneShot] Hit max_turns (hasEdited=${runState.hasEdited}) — treating as success`);
+      runState.resultText = (runState.resultText || '') + '\n\n*[Ran out of turns — send another message to continue where I left off]*';
+    } else if (!runState.errorSent) {
       onEvent({ type: 'error', message: stderrBuffer.slice(0, 500) || `Claude exited with code ${exitCode}` });
       return null;
     }
@@ -661,26 +733,26 @@ export async function runOneShot(
   // treat as a hard error. When hasEdited, the file was written but trailing
   // content (explanatory text, follow-up edits) may be missing — warn but
   // continue so the user at least sees a working app.
-  if (hitMaxTokens && !errorSent) {
-    if (!hasEdited) {
+  if (runState.hitMaxTokens && !runState.errorSent) {
+    if (!runState.hasEdited) {
       onEvent({
         type: 'error',
         message: 'Claude hit the output token limit before writing the file. Try a simpler prompt, or raise CLAUDE_CODE_MAX_OUTPUT_TOKENS.',
       });
-      errorSent = true;
+      runState.errorSent = true;
       return null;
     }
     console.warn(`[OneShot] max_tokens after file written — trailing content may be truncated`);
-    resultText = (resultText || '') + '\n\n*[Output was truncated at the token limit — the app was written but some follow-up content may be missing.]*';
+    runState.resultText = (runState.resultText || '') + '\n\n*[Output was truncated at the token limit — the app was written but some follow-up content may be missing.]*';
   }
 
   // Post-process
-  if (hasEdited) {
+  if (runState.hasEdited) {
     sanitizeAppJsx(projectRoot);
   }
 
   let appJsxValid: boolean | undefined = undefined;
-  if (hasEdited && opts.cwd) {
+  if (runState.hasEdited && opts.cwd) {
     const appPath = `${opts.cwd}/app.jsx`;
     try {
       appJsxValid = validateAppJsx(appPath).ok;
@@ -689,20 +761,20 @@ export async function runOneShot(
     }
   }
 
-  if (!errorSent) {
+  if (!runState.errorSent) {
     onEvent({
       type: 'complete',
-      text: resultText || 'Done.',
-      toolsUsed,
+      text: runState.resultText || 'Done.',
+      toolsUsed: runState.toolsUsed,
       elapsed: getElapsed(),
-      hasEdited,
+      hasEdited: runState.hasEdited,
       skipChat: opts.skipChat,
-      maxTokensHit: hitMaxTokens,
+      maxTokensHit: runState.hitMaxTokens,
       appJsxValid,
     });
   }
 
-  return resultText || null;
+  return runState.resultText || null;
 }
 
 // --- Re-exports from legacy module ---

--- a/scripts/server/handlers/generate.ts
+++ b/scripts/server/handlers/generate.ts
@@ -58,10 +58,30 @@ export async function handleGenerate(ctx: ServerContext, onEvent: EventCallback,
   if (result.isReference) {
     const maxTurns = result.isHtmlRef ? 10 : 12;
     console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
-    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+
+    // Reference preview: show the user their uploaded reference asset in the
+    // iframe while Claude is analyzing it. Only for HTML and image refs;
+    // text-file refs (seed/content/context intents) skip this — their content
+    // doesn't visualize meaningfully and the user already saw it on upload.
+    const refName = reference?.name as string | undefined;
+    const isTextRef = !!refName && /\.(txt|md|csv|tsv|json|xml|rtf)$/i.test(refName);
+    if (refName && !isTextRef) {
+      const refKind = result.isHtmlRef ? 'html' : 'image';
+      const vibesTmpPath = join(ctx.projectRoot, '.vibes-tmp', refName);
+      if (existsSync(vibesTmpPath)) {
+        onEvent({
+          type: 'reference_preview',
+          src: `/reference-frame?name=${encodeURIComponent(refName)}&kind=${refKind}`,
+        });
+      }
+    }
+
+    onEvent({ type: 'generation_stage', stage: 'reading_reference' });
+    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read', initialStage: 'reading_reference' }, onEvent, ctx.projectRoot);
   } else {
     console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
-    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
+    onEvent({ type: 'generation_stage', stage: 'foundation' });
+    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read', initialStage: 'foundation' }, onEvent, ctx.projectRoot);
   }
 
   sanitizeAppJsx(appDir);

--- a/scripts/server/handlers/generate.ts
+++ b/scripts/server/handlers/generate.ts
@@ -56,12 +56,12 @@ export async function handleGenerate(ctx: ServerContext, onEvent: EventCallback,
   onEvent({ type: 'theme_selected', themeId: result.themeId, themeName: result.themeName, themeBackground: themeColors?.bg || null });
 
   if (result.isReference) {
-    const maxTurns = result.isHtmlRef ? 5 : 8;
+    const maxTurns = result.isHtmlRef ? 10 : 12;
     console.log(`[Generate] Starting (reference path) — ref: ${reference.name} (${result.referenceIntent}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
-    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: result.isHtmlRef ? 'Write' : 'Write,Read' }, onEvent, ctx.projectRoot);
+    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
   } else {
     console.log(`[Generate] Starting — theme: ${result.themeId} (${result.themeName}), prompt: ${(result.prompt.length / 1024).toFixed(1)}KB`);
-    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 5, model, cwd: appDir, tools: 'Write' }, onEvent, ctx.projectRoot);
+    await runOneShot(result.prompt, { lockType: 'generate', skipChat: true, maxTurns: 10, model, cwd: appDir, tools: 'Write,Edit,Read' }, onEvent, ctx.projectRoot);
   }
 
   sanitizeAppJsx(appDir);

--- a/scripts/server/handlers/reference-frame.ts
+++ b/scripts/server/handlers/reference-frame.ts
@@ -17,9 +17,9 @@ import { existsSync, readFileSync, statSync } from 'fs';
 import { join, extname } from 'path';
 import type { ServerContext } from '../config.ts';
 
-function corsHeaders(): Record<string, string> {
+function corsHeaders(ctx: ServerContext): Record<string, string> {
   return {
-    'Access-Control-Allow-Origin': `http://localhost:3333`,
+    'Access-Control-Allow-Origin': `http://localhost:${ctx.port}`,
     'Vary': 'Origin',
   };
 }
@@ -48,26 +48,26 @@ export function serveReferenceFrame(ctx: ServerContext, url: URL): Response {
   const kind = url.searchParams.get('kind') || '';
 
   if (!isSafeName(name)) {
-    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+    return new Response('Bad Request', { status: 400, headers: corsHeaders(ctx) });
   }
 
   const refDir = join(ctx.projectRoot, '.vibes-tmp');
   const filePath = join(refDir, name);
   if (!filePath.startsWith(refDir + '/')) {
-    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+    return new Response('Bad Request', { status: 400, headers: corsHeaders(ctx) });
   }
   if (!existsSync(filePath) || !statSync(filePath).isFile()) {
-    return new Response('Not Found', { status: 404, headers: corsHeaders() });
+    return new Response('Not Found', { status: 404, headers: corsHeaders(ctx) });
   }
 
   if (kind === 'html') {
     const body = readFileSync(filePath, 'utf-8');
-    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders(ctx) } });
   }
 
   if (kind === 'raw') {
     const bytes = readFileSync(filePath);
-    return new Response(bytes, { headers: { 'Content-Type': contentTypeFor(name), ...corsHeaders() } });
+    return new Response(bytes, { headers: { 'Content-Type': contentTypeFor(name), ...corsHeaders(ctx) } });
   }
 
   // kind === 'image' (or default): wrap in a minimal full-bleed shell
@@ -81,5 +81,5 @@ export function serveReferenceFrame(ctx: ServerContext, url: URL): Response {
   </style>
 </head>
 <body><img src="${rawSrc}" alt="reference"></body></html>`;
-  return new Response(shell, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+  return new Response(shell, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders(ctx) } });
 }

--- a/scripts/server/handlers/reference-frame.ts
+++ b/scripts/server/handlers/reference-frame.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /reference-frame — serve the user-uploaded reference asset inside
+ * an iframe-friendly wrapper so the preview iframe can show it while
+ * Claude is analyzing it in Step 1 of generation.
+ *
+ * Supported kinds:
+ *   - html: serve the file as-is with text/html (for HTML references)
+ *   - image: wrap the image in a minimal full-bleed HTML shell
+ *   - raw: return the raw file bytes (used by the image shell's <img src>)
+ *
+ * Security: the `name` query parameter is validated to be a plain filename
+ * (no slashes, no ..). The file is looked up only under the known reference
+ * directory (.vibes-tmp/) relative to projectRoot.
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join, extname } from 'path';
+import type { ServerContext } from '../config.ts';
+
+function corsHeaders(): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': `http://localhost:3333`,
+    'Vary': 'Origin',
+  };
+}
+
+function isSafeName(name: string): boolean {
+  return !!name && !name.includes('/') && !name.includes('\\') && !name.includes('..') && name.length <= 200;
+}
+
+function contentTypeFor(name: string): string {
+  const ext = extname(name).toLowerCase();
+  switch (ext) {
+    case '.png': return 'image/png';
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg';
+    case '.gif': return 'image/gif';
+    case '.webp': return 'image/webp';
+    case '.svg': return 'image/svg+xml';
+    case '.ico': return 'image/x-icon';
+    case '.avif': return 'image/avif';
+    default: return 'application/octet-stream';
+  }
+}
+
+export function serveReferenceFrame(ctx: ServerContext, url: URL): Response {
+  const name = url.searchParams.get('name') || '';
+  const kind = url.searchParams.get('kind') || '';
+
+  if (!isSafeName(name)) {
+    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+  }
+
+  const refDir = join(ctx.projectRoot, '.vibes-tmp');
+  const filePath = join(refDir, name);
+  if (!filePath.startsWith(refDir + '/')) {
+    return new Response('Bad Request', { status: 400, headers: corsHeaders() });
+  }
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+    return new Response('Not Found', { status: 404, headers: corsHeaders() });
+  }
+
+  if (kind === 'html') {
+    const body = readFileSync(filePath, 'utf-8');
+    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+  }
+
+  if (kind === 'raw') {
+    const bytes = readFileSync(filePath);
+    return new Response(bytes, { headers: { 'Content-Type': contentTypeFor(name), ...corsHeaders() } });
+  }
+
+  // kind === 'image' (or default): wrap in a minimal full-bleed shell
+  const rawSrc = `/reference-frame?name=${encodeURIComponent(name)}&kind=raw`;
+  const shell = `<!DOCTYPE html>
+<html><head>
+  <meta charset="utf-8">
+  <style>
+    html,body { margin:0; padding:0; height:100%; background:#000; }
+    img { display:block; width:100%; height:100%; object-fit:contain; }
+  </style>
+</head>
+<body><img src="${rawSrc}" alt="reference"></body></html>`;
+  return new Response(shell, { headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders() } });
+}

--- a/scripts/server/prompt-builders.ts
+++ b/scripts/server/prompt-builders.ts
@@ -33,6 +33,74 @@ const EFFECT_INSTRUCTIONS = {
   'shader': `MANDATORY: Add a WebGL fragment shader background. Create a fullscreen quad with vertex shader, pass u_time/u_resolution/u_mouse uniforms. Use effects like: aurora (sine wave color mixing), plasma (layered sine interference), noise gradient mesh (hash-based noise with mouse reactivity), or animated color fields. Use precision mediump float. Graceful fallback if WebGL unavailable.`,
 };
 
+/**
+ * The boilerplate JSX block every generated app.jsx must start with.
+ * Shared between the reference and non-reference paths.
+ */
+function USE_VIBES_THEME_TEMPLATE(themeId: string, themeName: string): string {
+  return `\`\`\`jsx
+window.__VIBES_THEMES__ = [{ id: "${themeId}", name: "${themeName}" }];
+
+function useVibesTheme() {
+  const [theme, setTheme] = React.useState(() => localStorage.getItem("vibes-theme") || "${themeId}");
+  React.useEffect(() => {
+    const handler = (e) => { const t = e.detail?.theme; if (t) { setTheme(t); localStorage.setItem("vibes-theme", t); } };
+    document.addEventListener("vibes-design-request", handler);
+    return () => document.removeEventListener("vibes-design-request", handler);
+  }, []);
+  return theme;
+}
+\`\`\``;
+}
+
+/**
+ * Cross-cutting rules that apply to every step of the 2-step generation.
+ * Kept in one place so the reference and non-reference prompts share identical text.
+ */
+const GLOBAL_STEP_RULES = `=== RULES THAT APPLY TO ALL STEPS ===
+
+- NO import statements — the app runs in a Babel script block with globals
+- NO TypeScript. End the file with: export default App
+- Never use CSS unicode escapes (\\2192, \\2022, \\00BB). Use actual Unicode characters: → ● « etc. CSS escapes break Babel.
+- Responsive (mobile-first with Tailwind). Use className="btn" for buttons, className="grid-background" on the root element.
+- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue, useSortedRowIds, useTable) are PRE-EXISTING GLOBALS. NEVER import, redeclare, or alias them.
+- Table names must be string literals: useRowIds('todos'), never useRowIds(tableName).
+- Cells are scalars only (string/number/boolean) — no nested objects or arrays.
+- No sync/connection status UI, not even decorative ("Online", "LIVE", "Connected") — SyncStatusDot is built-in.
+- useApp() is mandatory in root App. It returns { isReady, isSyncing, user }.`;
+
+/**
+ * The core new behavior: tell Claude to produce the app via two tool calls.
+ * Claude Code's native tool loop turns each tool_result into a new assistant turn
+ * with its own fresh max_tokens budget — so we don't need server-side orchestration.
+ */
+const TWO_STEP_INSTRUCTIONS = `=== BUILD app.jsx IN TWO TOOL CALLS ===
+
+Build this app in two separate tool calls, in order. Each step has a specific purpose; do not try to do everything in one call.
+
+STEP 1 — Write app.jsx: the visible skeleton.
+Produce a file that compiles and renders the app's basic shape — even without data or interactions. Include:
+- The exact __VIBES_THEMES__ + useVibesTheme code from above (unchanged)
+- A <style> tag with :root tokens and the four marker sections (/* @theme:tokens */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS
+- A functioning component tree with visible elements: header with the app title, main content area, whatever structural regions fit this app (sidebar/nav/footer as needed). Components render placeholder/empty states but the layout is real.
+- Basic React hooks for local UI state (useState). NO TinyBase hooks yet. NO event handlers yet.
+- export default App
+
+After STEP 1 the preview should look like the final app in colors, typography, and layout — just without data or polish.
+
+STEP 2 — Edit app.jsx: data, interactions, and polish.
+Read app.jsx (the skeleton you just wrote), then Edit it to add everything else:
+- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue)
+- React event handlers, effects, refs
+- useApp() integration; useAI wiring if the app needs it
+- Inside the @theme:surfaces marker: shadows, borders, gradients, glass effects
+- Inside the @theme:motion marker: @keyframes, CSS @property animations, hover effects
+- Inside the @theme:decoration marker: SVG illustrations, Canvas 2D or WebGL backgrounds, decorative patterns
+
+After STEP 2 the app is complete.
+
+IMPORTANT: Do NOT produce a <design> narrative before STEP 1. Any design notes belong inside CSS comments in the <style> tag. Narrative prose counts against the same output budget as your code.`;
+
 // --- Auto-detect reference files from user message keywords ---
 
 const REFERENCE_TRIGGERS: Array<{ keywords: RegExp; file: string; label: string }> = [
@@ -309,19 +377,7 @@ USER REQUEST: "${userPrompt}"
 
 Your app.jsx MUST start with these EXACT lines (copy-paste, do not modify):
 
-\`\`\`jsx
-window.__VIBES_THEMES__ = [{ id: "custom-ref", name: "Custom Reference" }];
-
-function useVibesTheme() {
-  const [theme, setTheme] = React.useState(() => localStorage.getItem("vibes-theme") || "custom-ref");
-  React.useEffect(() => {
-    const handler = (e) => { const t = e.detail?.theme; if (t) { setTheme(t); localStorage.setItem("vibes-theme", t); } };
-    document.addEventListener("vibes-design-request", handler);
-    return () => document.removeEventListener("vibes-design-request", handler);
-  }, []);
-  return theme;
-}
-\`\`\`
+${USE_VIBES_THEME_TEMPLATE('custom-ref', 'Custom Reference')}
 
 Derive ALL :root CSS tokens from the design reference above — do NOT use any predefined theme.
 
@@ -336,17 +392,9 @@ Briefly note design decisions inside CSS comments in the <style> tag — not as 
 - Custom SVG illustrations that fit
 - Animations that match the reference mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
 
-=== WRITE app.jsx ===
+${TWO_STEP_INSTRUCTIONS}
 
-Write the complete app to app.jsx. Rules:
-- FIRST: the exact __VIBES_THEMES__ + useVibesTheme code shown above
-- THEN: <style> tag with reference-derived CSS organized into marked sections (see below), plus component styles
-- Add rich visual effects: Canvas 2D backgrounds, animated SVG illustrations, CSS @property animations, hover effects
-- JSX with React hooks (useState, useEffect, useRef, useCallback, useMemo)
-- NO import statements — runs in Babel script block with globals
-- NO TypeScript. End with: export default App
-- Never use CSS unicode escapes (\\2192, \\2022, \\00BB). Use actual Unicode characters instead: → ● « etc. CSS escapes break Babel.
-- Responsive (mobile-first with Tailwind). className="btn" for buttons, "grid-background" on root
+${GLOBAL_STEP_RULES}
 
 ${THEME_SECTION_MARKERS}
 ${useAI ? AI_INSTRUCTIONS_GENERATE : ''}`;
@@ -403,19 +451,7 @@ USER REQUEST: "${userPrompt}"
 
 Your app.jsx MUST start with these EXACT lines (copy-paste, do not modify):
 
-\`\`\`jsx
-window.__VIBES_THEMES__ = [{ id: "${themeId}", name: "${themeName}" }];
-
-function useVibesTheme() {
-  const [theme, setTheme] = React.useState(() => localStorage.getItem("vibes-theme") || "${themeId}");
-  React.useEffect(() => {
-    const handler = (e) => { const t = e.detail?.theme; if (t) { setTheme(t); localStorage.setItem("vibes-theme", t); } };
-    document.addEventListener("vibes-design-request", handler);
-    return () => document.removeEventListener("vibes-design-request", handler);
-  }, []);
-  return theme;
-}
-\`\`\`
+${USE_VIBES_THEME_TEMPLATE(themeId!, themeName)}
 
 Your <style> tag MUST include these EXACT CSS custom properties from the "${themeName}" theme:
 
@@ -438,17 +474,9 @@ Briefly note design decisions inside CSS comments in the <style> tag — not as 
 - What custom SVG illustrations fit this app
 - What animations match the theme mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
 
-=== WRITE app.jsx ===
+${TWO_STEP_INSTRUCTIONS}
 
-Write the complete app to app.jsx. Rules:
-- FIRST: the exact __VIBES_THEMES__ + useVibesTheme code shown above
-- THEN: <style> tag with theme-sensitive CSS organized into marked sections (see below), plus component styles
-- Add rich visual effects: Canvas 2D backgrounds, animated SVG illustrations, CSS @property animations, hover effects
-- JSX with React hooks (useState, useEffect, useRef, useCallback, useMemo)
-- NO import statements — runs in Babel script block with globals
-- NO TypeScript. End with: export default App
-- Never use CSS unicode escapes (\\2192, \\2022, \\00BB). Use actual Unicode characters instead: → ● « etc. CSS escapes break Babel.
-- Responsive (mobile-first with Tailwind). className="btn" for buttons, "grid-background" on root
+${GLOBAL_STEP_RULES}
 
 ${THEME_SECTION_MARKERS}
 ${useAI ? AI_INSTRUCTIONS_GENERATE : ''}`;

--- a/scripts/server/prompt-builders.ts
+++ b/scripts/server/prompt-builders.ts
@@ -56,18 +56,43 @@ function useVibesTheme() {
 /**
  * Cross-cutting rules that apply to every step of the 2-step generation.
  * Kept in one place so the reference and non-reference prompts share identical text.
+ *
+ * Note: rules that also appear in RECENCY_REMINDER (no imports, useApp mandatory,
+ * cells scalar, no sync UI, table names literal) are intentionally omitted here —
+ * RECENCY_REMINDER emits earlier in the prompt and already covers those invariants.
+ * This block focuses on the rules specific to the multi-step generation flow.
  */
 const GLOBAL_STEP_RULES = `=== RULES THAT APPLY TO ALL STEPS ===
 
-- NO import statements — the app runs in a Babel script block with globals
 - NO TypeScript. End the file with: export default App
 - Never use CSS unicode escapes (\\2192, \\2022, \\00BB). Use actual Unicode characters: → ● « etc. CSS escapes break Babel.
 - Responsive (mobile-first with Tailwind). Use className="btn" for buttons, className="grid-background" on the root element.
-- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue, useSortedRowIds, useTable) are PRE-EXISTING GLOBALS. NEVER import, redeclare, or alias them.
-- Table names must be string literals: useRowIds('todos'), never useRowIds(tableName).
-- Cells are scalars only (string/number/boolean) — no nested objects or arrays.
-- No sync/connection status UI, not even decorative ("Online", "LIVE", "Connected") — SyncStatusDot is built-in.
-- useApp() is mandatory in root App. It returns { isReady, isSyncing, user }.`;
+- TinyBase hooks (useRowIds, useCell, useAddRowCallback, useSetCellCallback, useDelRowCallback, useValue, useSortedRowIds, useTable) are PRE-EXISTING GLOBALS — explicit names so you know what's available.
+- useApp() returns { isReady, isSyncing, user }.`;
+
+/**
+ * The "Think about design decisions inline in CSS comments" block.
+ *
+ * Shared between the reference and non-reference prompt paths. Differs only in
+ * the first two bullets (reference mentions extracted tokens; non-reference
+ * names the theme personality) and the word `reference`/`theme` in the mood
+ * phrase.
+ */
+function DESIGN_REASONING_SECTION(opts: { isReference: boolean; themeName?: string }): string {
+  const firstBullet = opts.isReference
+    ? 'Colors, typography, and surfaces extracted from the reference and their mapping to --comp-* tokens'
+    : `How "${opts.themeName}" personality shapes visual choices`;
+  const secondBullet = opts.isReference
+    ? 'Custom SVG illustrations that fit'
+    : 'What custom SVG illustrations fit this app';
+  const moodLabel = opts.isReference ? 'reference' : 'theme';
+  return `=== DESIGN REASONING ===
+
+Briefly note design decisions inside CSS comments in the <style> tag — not as a separate <design> narrative before the Write. Consider:
+- ${firstBullet}
+- ${secondBullet}
+- Animations that match the ${moodLabel} mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)`;
+}
 
 /**
  * The core new behavior: tell Claude to produce the app via two tool calls.
@@ -385,12 +410,7 @@ Derive ALL :root CSS tokens from the design reference above — do NOT use any p
 
 ${styleGuide}
 
-=== DESIGN REASONING ===
-
-Briefly note design decisions inside CSS comments in the <style> tag — not as a separate <design> narrative before the Write. Consider:
-- Colors, typography, and surfaces extracted from the reference and their mapping to --comp-* tokens
-- Custom SVG illustrations that fit
-- Animations that match the reference mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
+${DESIGN_REASONING_SECTION({ isReference: true })}
 
 ${TWO_STEP_INSTRUCTIONS}
 
@@ -467,12 +487,7 @@ ${themeEssentials || 'Creative, polished, and distinctive.'}
 
 ${styleGuide}
 
-=== DESIGN REASONING ===
-
-Briefly note design decisions inside CSS comments in the <style> tag — not as a separate <design> narrative before the Write. Consider:
-- How "${themeName}" personality shapes visual choices
-- What custom SVG illustrations fit this app
-- What animations match the theme mood (Canvas particles, animated SVG, scroll reveals, card tilt, cursor glow)
+${DESIGN_REASONING_SECTION({ isReference: false, themeName })}
 
 ${TWO_STEP_INSTRUCTIONS}
 

--- a/scripts/server/router.ts
+++ b/scripts/server/router.ts
@@ -13,6 +13,7 @@ import type { ServerContext } from './config.ts';
 import { getRecommendedThemeIds, loadOpenRouterKey } from './config.ts';
 import { resolveProjectDir, resolveAppJsxPath } from './app-context.js';
 import { assembleAppFrame } from './handlers/generate.ts';
+import { serveReferenceFrame } from './handlers/reference-frame.ts';
 import { loadRegistry, saveRegistry, getCloudflareConfig, setCloudflareConfig, getApp, setApp, addRecentProject, getRecentProjects } from '../lib/registry.js';
 import { pickFolder } from '../lib/folder-picker.js';
 import { initVibesJson, readVibesJson, writeVibesJson } from '../lib/vibes-json.js';
@@ -866,6 +867,7 @@ export function createRouter(ctx: ServerContext) {
       case 'GET /animations':               return serveAnimations(ctx);
       case 'GET /skills':                    return serveSkills(ctx);
       case 'GET /app-frame':                return serveAppFrame(ctx, url);
+      case 'GET /reference-frame':          return serveReferenceFrame(ctx, url);
       case 'GET /editor/status':            return editorStatus(ctx);
       case 'POST /editor/auth/login':       return editorAuthLogin(ctx);
       case 'POST /editor/auth/logout':      return editorAuthLogout();

--- a/skills/vibes/templates/editor.html
+++ b/skills/vibes/templates/editor.html
@@ -1126,6 +1126,41 @@
       height: 100%;
       border: none;
     }
+    /* Generation overlay (Direction D multi-turn) — distinct from .preview-overlay */
+    .gen-overlay {
+      position: absolute;
+      inset: 0;
+      background: rgba(10, 10, 10, 0.55);
+      backdrop-filter: blur(4px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: auto; /* absorb clicks on the skeleton */
+      z-index: 10;
+      transition: opacity 120ms ease;
+    }
+    .gen-overlay[hidden] { display: none; }
+    .gen-overlay-card {
+      background: rgba(24, 24, 28, 0.9);
+      color: #eaeaea;
+      padding: 14px 20px;
+      border-radius: 10px;
+      font: 500 13px/1.4 system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    }
+    .gen-overlay-card.error { background: rgba(80, 30, 30, 0.92); }
+    .gen-overlay-spinner {
+      width: 14px; height: 14px;
+      border: 2px solid rgba(255,255,255,0.25);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: gen-overlay-spin 0.8s linear infinite;
+    }
+    .gen-overlay-card.error .gen-overlay-spinner { display: none; }
+    @keyframes gen-overlay-spin { to { transform: rotate(360deg); } }
 
     /* Undo/Redo bar — hidden until there's history to navigate */
     .version-bar {
@@ -3172,7 +3207,15 @@
         </svg>
         <div class="preview-progress-label" id="previewProgressLabel">Starting Claude...</div>
       </div>
-      <iframe class="preview-iframe" id="previewFrame" src="about:blank"></iframe>
+      <div class="preview-container" id="previewContainer" style="position:relative; width:100%; height:100%;">
+        <iframe class="preview-iframe" id="previewFrame" src="about:blank"></iframe>
+        <div class="gen-overlay" id="genOverlay" hidden>
+          <div class="gen-overlay-card" id="genOverlayCard">
+            <div class="gen-overlay-spinner"></div>
+            <div class="gen-overlay-text" id="genOverlayText">Starting...</div>
+          </div>
+        </div>
+      </div>
       <div class="version-bar" id="versionBar">
         <button class="version-btn" id="undoBtn" onclick="versionUndo()" disabled data-tooltip="Undo">&#8592;</button>
         <span class="version-count" id="versionCount"></span>
@@ -4202,10 +4245,102 @@ window.escapeHtml = function(str) {
       }
     };
 
+    // --- Generation overlay state ---
+    const OVERLAY_COPY = {
+      reading_reference: 'Analyzing reference — extracting design...',
+      foundation: 'Step 1 of 2 — Foundation',
+      interactions: 'Step 2 of 2 — Building interactions and polish',
+      preview_reload_failed_foundation: 'Step 1 produced a syntax error — waiting for retry...',
+      preview_reload_failed_interactions: 'Step 2 produced a syntax error — continuing...',
+    };
+
+    let overlayCurrentStage = null;
+    let overlayInError = false;
+
+    function setOverlayVisible(visible) {
+      const o = document.getElementById('genOverlay');
+      if (!o) return;
+      if (visible) { o.hidden = false; } else { o.hidden = true; }
+    }
+
+    function setOverlayText(text, isError) {
+      const t = document.getElementById('genOverlayText');
+      const card = document.getElementById('genOverlayCard');
+      if (t) t.textContent = text;
+      if (card) card.classList.toggle('error', !!isError);
+    }
+
+    function handleGenerationStage(stage) {
+      overlayCurrentStage = stage;
+      if (overlayInError && stage === 'interactions') {
+        // Recovery: a new stage event clears the error state
+        overlayInError = false;
+      }
+      if (!overlayInError) {
+        setOverlayText(OVERLAY_COPY[stage] || stage, false);
+        setOverlayVisible(true);
+      }
+    }
+
+    function handlePreviewReload() {
+      // Cache-bust the preview iframe. Reuse the exact appParam derivation pattern
+      // used at the existing reload call site (around line 5066-5067 in this file)
+      // — currentProjectDir is a full path, so we derive `name` from it.
+      const frame = document.getElementById('previewFrame');
+      if (!frame) return;
+      if (overlayInError) overlayInError = false; // recovery: successful reload clears error
+      const name = currentProjectDir ? currentProjectDir.split('/').pop() : currentAppName;
+      const appParam = name ? 'app=' + encodeURIComponent(name) + '&' : '';
+      frame.src = '/app-frame?' + appParam + 't=' + Date.now();
+      // After a successful reload, restore the normal overlay copy for the current stage
+      if (overlayCurrentStage) setOverlayText(OVERLAY_COPY[overlayCurrentStage] || overlayCurrentStage, false);
+    }
+
+    function handlePreviewReloadFailed(stage) {
+      overlayInError = true;
+      const key = 'preview_reload_failed_' + stage;
+      setOverlayText(OVERLAY_COPY[key] || 'Syntax error — continuing...', true);
+    }
+
+    function handleReferencePreview(src) {
+      const frame = document.getElementById('previewFrame');
+      if (!frame) return;
+      frame.src = src;
+    }
+
+    function handleGenerationComplete(appJsxValid) {
+      setOverlayVisible(false);
+      overlayCurrentStage = null;
+      overlayInError = false;
+      if (appJsxValid === false) {
+        // Surface a persistent error chip / toast — project-specific UI hook.
+        // For now, just log; a later polish pass can attach to the existing toast system.
+        console.warn('[generate] app.jsx did not pass final validation');
+      }
+    }
+
     ws.onmessage = (event) => {
       const msg = JSON.parse(event.data);
       // DEBUG: log all incoming WS events
       if (msg.type !== 'token') console.log('[WS-IN]', msg.type, msg.type === 'tool_result' ? msg.name : '', msg.type === 'complete' ? 'usage:' + JSON.stringify(msg.usage) : '');
+
+      // --- Direction D multi-turn generation events ---
+      if (msg.type === 'generation_stage') {
+        handleGenerationStage(msg.stage);
+        return;
+      }
+      if (msg.type === 'preview_reload') {
+        handlePreviewReload();
+        return;
+      }
+      if (msg.type === 'preview_reload_failed') {
+        handlePreviewReloadFailed(msg.stage);
+        return;
+      }
+      if (msg.type === 'reference_preview') {
+        handleReferencePreview(msg.src);
+        return;
+      }
 
       // After interrupt, ignore trailing events until the turn completes
       if (interrupted) {
@@ -4267,6 +4402,7 @@ window.escapeHtml = function(str) {
         // Return to "Thinking..." after tool completes
         setThinking(true, null, 'Thinking...');
       } else if (msg.type === 'complete') {
+        handleGenerationComplete(msg.appJsxValid);
         // Run finished — finalize streaming bubble, update status
         setThinking(false);
         if (msg.usage) {


### PR DESCRIPTION
## Summary

Implements Direction D from the [design spec](docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md). Vibes OS app generation now uses **two Claude tool calls** (Write skeleton → Edit rest) via Claude Code's native tool loop, so each step gets its own fresh `max_tokens` budget. Along the way, the preview iframe updates in stages — reference asset → skeleton → complete — with an overlay communicating progress.

Companion to the already-shipped PR #68 (`max_tokens` floor + instrumentation).

### Why prompt-driven multi-turn, not an orchestrator

We deliberately avoided adopting the Agent SDK's `resume: sessionId` or building our own session-staging harness. Philosophy: Vibes OS is a UI layer over Claude Code, not a harness reinvention. The mechanic here leans on a primitive Claude Code already provides — each `tool_result` triggers a new assistant turn. No orchestration code needed.

## What's in here (10 commits)

Core feature:

- `refactor(generate):` — extract shared prompt constants; switch the prompt to "BUILD app.jsx IN TWO TOOL CALLS" framing
- `feat(generate):` — allow `Write,Edit,Read` tools; raise `--max-turns` to 10/10/12 across the three paths
- `feat(lib):` — `validateAppJsx` parse-check helper using esbuild
- `feat(bridge):` — emit `generation_stage`, `preview_reload`, `preview_reload_failed`, `reference_preview`; add `appJsxValid` field on the `complete` event
- `feat(server):` — new `GET /reference-frame` route serving user-uploaded reference assets to the iframe
- `feat(editor):` — overlay above the preview iframe; swap iframe src on `reference_preview`; cache-bust on `preview_reload`; error state on `preview_reload_failed`. Named with `gen*` prefix to avoid colliding with the existing `previewOverlay` ASCII-logo loader
- `chore:` — bump to `0.3.0`

Follow-up cleanups (all flagged in code-quality reviews during implementation, all now landed):

- `fix(reference-frame):` — thread `ctx.port` into the CORS `Access-Control-Allow-Origin` header so it works on non-default ports
- `refactor(generate):` — extract `DESIGN_REASONING_SECTION` helper so the reference and non-reference paths share the design-reasoning block; trim `GLOBAL_STEP_RULES` to remove bullets already covered by `RECENCY_REMINDER`
- `refactor(bridge):` — extract the `runOneShot` stream-parser dispatch callback into an exported, testable `dispatchStreamEvent` function with explicit `OneShotRunState`. Replaces the Phase 4 `it.skip` stub with 7 real tests covering the non-reference happy path, reference happy path, `preview_reload` gating on `app.jsx` + validator, `preview_reload_failed`, and `max_tokens` detection

## Test plan

- [x] All unit tests pass (`cd scripts && npm run test:unit` → **711 passed across 45 files, 0 skipped**)
- [x] Stream-parser emission sequence covered by real unit tests (was a stub)
- [ ] Manual (deferred to reviewer or post-merge): non-reference generation; image-ref; HTML-ref; text-ref with `intent=seed`; force a syntax error to exercise `preview_reload_failed`
- [ ] `/vibes:test` E2E
- [ ] Log compliance check post-merge: ≥2 `preview_reload` events per generation in typical use (spec success metric)

## Spec + plan

- [Design spec](docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md)
- [Implementation plan](docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md)