### PR TITLE
chore: reset version to 0.2.151

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "vibes",
       "source": "./",
       "description": "Vibes is for people who use Claude Code, but don't know how to code.",
-      "version": "0.3.0",
+      "version": "0.2.151",
       "author": {
         "name": "Marcus Estes",
         "email": "marcus@vibes.diy"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibes",
-  "version": "0.3.0",
+  "version": "0.2.151",
   "description": "Vibes is for people who use Claude Code, but don't know how to code.",
   "author": {
     "name": "Marcus Estes",


### PR DESCRIPTION
Follow-up to PR #69. That PR bumped the minor version from `0.2.15` to `0.3.0`; walking that back to `0.2.151` to keep this release inside the `0.2.x` line.

Both files updated:
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

No code changes.