### PR TITLE
fix(assembly): injectCode helper — avoid String.replace special patterns

### DIFF
--- a/scripts/__tests__/unit/assemble-validation.test.js
+++ b/scripts/__tests__/unit/assemble-validation.test.js
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { APP_PLACEHOLDER, validateAssembly, checkForbiddenPatterns } from '../../lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode, validateAssembly, checkForbiddenPatterns } from '../../lib/assembly-utils.js';
 import {
   SAFE_PLACEHOLDER_PATTERNS,
   validateFactoryTemplate,
@@ -80,6 +80,56 @@ describe('validateAssembly', () => {
     const errors = validateAssembly(html, '');
     expect(errors.length).toBeGreaterThanOrEqual(2);
     expect(errors).toContain('App code is empty');
+  });
+});
+
+describe('injectCode', () => {
+  // `String.prototype.replace(str, str)` treats $', $&, $`, $1–$9 as special
+  // patterns. A raw-string replacement would expand them — e.g. `$'` becomes the
+  // substring after the match. `injectCode` passes a function callback instead,
+  // which receives the code verbatim. Regression: currency `prefix: '$'`
+  // literals in KMUN-translator/app.jsx produced 10k-line garbled output.
+
+  const template = `HEAD ${PLACEHOLDER} TAIL`;
+
+  it('substitutes plain code at the placeholder', () => {
+    const code = 'const x = 1;';
+    expect(injectCode(template, PLACEHOLDER, code)).toBe(`HEAD ${code} TAIL`);
+  });
+
+  it("does not expand $' (after-match pattern) in code", () => {
+    const code = "const currency = { prefix: '$' };";
+    const result = injectCode(template, PLACEHOLDER, code);
+    expect(result).toBe(`HEAD ${code} TAIL`);
+    expect(result).not.toContain(" TAIL TAIL");
+  });
+
+  it('does not expand $& (whole-match pattern) in code', () => {
+    const code = "const s = 'A $& B';";
+    const result = injectCode(template, PLACEHOLDER, code);
+    expect(result).toBe(`HEAD ${code} TAIL`);
+    expect(result).not.toContain(PLACEHOLDER + ' B');
+  });
+
+  it('does not expand $` (before-match pattern) in code', () => {
+    const code = "const s = 'A $` B';";
+    const result = injectCode(template, PLACEHOLDER, code);
+    expect(result).toBe(`HEAD ${code} TAIL`);
+    expect(result).not.toContain("A HEAD  B");
+  });
+
+  it('does not expand $1–$9 (capture-group patterns) in code', () => {
+    const code = 'const s = "price: $1 to $9";';
+    const result = injectCode(template, PLACEHOLDER, code);
+    expect(result).toBe(`HEAD ${code} TAIL`);
+  });
+
+  it("does not duplicate template tail when code has multiple $' sequences", () => {
+    // Simulates the KMUN bug: 20+ currency prefix literals
+    const code = Array(20).fill("prefix: '$'").join('; ') + ';';
+    const result = injectCode(template, PLACEHOLDER, code);
+    // Output length = HEAD + code + TAIL. No expansion means no extra TAILs.
+    expect((result.match(/TAIL/g) || []).length).toBe(1);
   });
 });
 

--- a/scripts/assemble-all.js
+++ b/scripts/assemble-all.js
@@ -13,7 +13,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { TEMPLATES } from './lib/paths.js';
-import { APP_PLACEHOLDER, loadAndValidateTemplate } from './lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode, loadAndValidateTemplate } from './lib/assembly-utils.js';
 import { stripForTemplate } from './lib/strip-code.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from './lib/auth-constants.js';
 
@@ -49,7 +49,7 @@ const results = await Promise.all(
     try {
       const appCode = readFileSync(appPath, 'utf8').trim();
       const cleanedCode = stripForTemplate(appCode, { stripReactHooks: true });
-      let output = template.replace(APP_PLACEHOLDER, cleanedCode);
+      let output = injectCode(template, APP_PLACEHOLDER, cleanedCode);
       output = output.replaceAll('__OIDC_AUTHORITY__', OIDC_AUTHORITY);
       output = output.replaceAll('__OIDC_CLIENT_ID__', OIDC_CLIENT_ID);
       output = output.replaceAll('__DEPLOY_API_URL__', DEPLOY_API_URL);

--- a/scripts/assemble-factory.js
+++ b/scripts/assemble-factory.js
@@ -38,7 +38,7 @@ import { createBackup } from './lib/backup.js';
 import { prompt } from './lib/prompt.js';
 import { populateConnectConfig } from './lib/env-utils.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from './lib/auth-constants.js';
-import { APP_PLACEHOLDER } from './lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode } from './lib/assembly-utils.js';
 import { parseArgs as parseCliArgs, formatHelp } from './lib/cli-utils.js';
 import { validateFactoryTemplate, validateFactoryAssembly } from './lib/factory-assembly-validation.js';
 
@@ -272,7 +272,7 @@ if (firepoolMatch) {
 
 // Insert app code at placeholder
 if (output.includes(APP_PLACEHOLDER)) {
-  output = output.replace(APP_PLACEHOLDER, appCode);
+  output = injectCode(output, APP_PLACEHOLDER, appCode);
 } else {
   console.error(`Template missing placeholder: ${APP_PLACEHOLDER}`);
   process.exit(1);
@@ -284,7 +284,7 @@ let adminCode = stripImports(readFileSync(adminComponentPath, 'utf8').trim());
 // Insert admin code at placeholder (optional - template may have inline admin)
 const adminPlaceholder = '__ADMIN_CODE__';
 if (output.includes(adminPlaceholder)) {
-  output = output.replace(adminPlaceholder, adminCode);
+  output = injectCode(output, adminPlaceholder, adminCode);
 } else {
   console.log('Note: Template has inline admin dashboard, skipping admin component injection');
 }

--- a/scripts/assemble.js
+++ b/scripts/assemble.js
@@ -16,7 +16,7 @@ import { resolve } from 'path';
 import { TEMPLATES } from './lib/paths.js';
 import { createBackup } from './lib/backup.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from './lib/auth-constants.js';
-import { APP_PLACEHOLDER, AUTH_INJECT_MARKER, validateAssembly, loadAndValidateTemplate, checkForbiddenPatterns, stripOidcImportBlock } from './lib/assembly-utils.js';
+import { APP_PLACEHOLDER, AUTH_INJECT_MARKER, injectCode, validateAssembly, loadAndValidateTemplate, checkForbiddenPatterns, stripOidcImportBlock } from './lib/assembly-utils.js';
 import { stripForTemplate } from './lib/strip-code.js';
 
 
@@ -60,7 +60,7 @@ async function main() {
   }
 
   // Assemble: insert app code at placeholder
-  let output = template.replace(APP_PLACEHOLDER, cleanedAppCode);
+  let output = injectCode(template, APP_PLACEHOLDER, cleanedAppCode);
 
   // Inject hardcoded OIDC constants (same for every app) — replaceAll for templates
   // with multiple occurrences of the same placeholder.

--- a/scripts/lib/assembly-utils.js
+++ b/scripts/lib/assembly-utils.js
@@ -8,6 +8,18 @@ export const APP_PLACEHOLDER = '// __VIBES_APP_CODE__';
 export const AUTH_INJECT_MARKER = '// <!-- AUTH:INJECT -->';
 
 /**
+ * Inject code into a template at a placeholder.
+ *
+ * Uses a function callback so `$` sequences in code aren't interpreted as
+ * String.prototype.replace special patterns ($', $&, $`, $1–$9). Passing the
+ * code as a raw string causes currency literals like `prefix: '$'` to expand
+ * `$'` into the template tail, duplicating output.
+ */
+export function injectCode(template, placeholder, code) {
+  return template.replace(placeholder, () => code);
+}
+
+/**
  * Load a template file and validate it contains the placeholder.
  * @param {string} templatePath - Path to template file
  * @param {Function} readFileFn - Function to read a file (default: fs.readFileSync)

--- a/scripts/server/handlers/generate.ts
+++ b/scripts/server/handlers/generate.ts
@@ -10,7 +10,7 @@ import type { EventCallback } from '../claude-bridge.ts';
 import { sanitizeAppJsx } from '../post-process.ts';
 import type { ServerContext } from '../config.ts';
 import { stripForTemplate } from '../../lib/strip-code.js';
-import { APP_PLACEHOLDER } from '../../lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode } from '../../lib/assembly-utils.js';
 import { populateConnectConfig } from '../../lib/env-utils.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from '../../lib/auth-constants.js';
 import { TEMPLATES } from '../../lib/paths.js';
@@ -115,7 +115,7 @@ export function assembleAppFrame(ctx, appName?: string) {
   if (!template.includes(APP_PLACEHOLDER)) {
     return `<html><body><h1>Template missing placeholder</h1><p>${APP_PLACEHOLDER}</p></body></html>`;
   }
-  template = template.replace(APP_PLACEHOLDER, strippedCode);
+  template = injectCode(template, APP_PLACEHOLDER, strippedCode);
 
   // Preview mode: inject safe defaults for TinyBase config (local-only, no sync, no auth).
   // Full config (wsUrl, oidcClientId) is injected at deploy time by the Deploy API.


### PR DESCRIPTION
## Summary

`String.prototype.replace(placeholder, code)` treats `\$'`, `\$&`, `` \$\` ``, and `\$1`–`\$9` in the **replacement string** as special patterns. When app code happens to contain these (e.g. currency literals like `prefix: '\$'`), the string form of `.replace()` expands them against the template — `\$'` in particular expands to "the substring after the match," duplicating the template tail.

**Concrete regression this fixes:** currency prefix literals in KMUN-translator/app.jsx produced ~10k-line garbled output during assembly.

## The fix

Added `injectCode(template, placeholder, code)` in `scripts/lib/assembly-utils.js`:

\`\`\`js
export function injectCode(template, placeholder, code) {
  return template.replace(placeholder, () => code);
}
\`\`\`

A **function** replacement receives the code verbatim — no pattern expansion.

Updated five call sites across the assembly pipeline to use it:

- \`scripts/assemble.js\`
- \`scripts/assemble-all.js\`
- \`scripts/assemble-factory.js\` (app + admin placeholders)
- \`scripts/server/handlers/generate.ts\` (\`assembleAppFrame\`)

## Tests

Six new tests in \`scripts/__tests__/unit/assemble-validation.test.js\` covering each special-pattern variant and the exact regression shape that hit KMUN (20 currency prefix literals → template tail appears exactly once).

## Test plan

- [x] \`cd scripts && npm run test:unit\` → 717 passed (was 711, +6 new)
- [ ] Manual: re-assemble a KMUN-style app with currency literals and confirm no tail duplication