### PR TITLE
docs(CLAUDE.md): document generate flow routing landmine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@
 | Editing auth components | `.claude/rules/auth-components.md` loads automatically |
 | Editing templates or build system | `.claude/rules/template-build.md` loads automatically |
 | Working on sharing/invites | `.claude/rules/sharing-architecture.md` loads automatically |
+| Working on generate/chat/theme server flow | See "Generate Flow Routing" below before editing `handlers/` |
 
 ### TinyBase API Reference
 
@@ -119,6 +120,25 @@ For subdomain routing tests, add to `/etc/hosts`:
 ```
 Then `npm run test:e2e:server` and open `http://test-app.local:3000`.
 
+## Generate Flow Routing
+
+**Landmine warning.** The editor's "generate" action does NOT route through `scripts/server/handlers/generate.ts:handleGenerate`. That handler exists but has zero call sites — it's effectively dead code. Grep before editing.
+
+The real flow: the editor sends a `{ type: 'generate', ... }` WebSocket message, which is handled in `scripts/server/ws.ts` at `case 'generate':` (around line 328). That branch wraps the user's prompt inside a brainstorm prompt (via `buildBrainstormPrompt`) and sends it through the **persistent bridge** (`createBridge` in `scripts/server/claude-bridge.ts`) via `b.sendMessage(...)`. The persistent bridge is used — not a one-shot subprocess — because the brainstorm Q&A is multi-turn: Claude asks clarifying questions, the user answers, and eventually Claude produces the brief and starts writing. All of that must happen in a single conversation.
+
+Chat iteration (`case 'chat':`) uses the same bridge — so the bridge's per-turn state needs to be reset between generate and chat turns. That's what `bridge.setTurnMode('generate' | 'chat', initialStage?)` is for — call it before every `sendMessage`.
+
+Stream-event translation has two parallel paths:
+
+| Path | Used by | Translator | UI events emitted |
+|---|---|---|---|
+| Persistent bridge | generate, chat, theme | `translateStreamEvent` (event-translator.ts) | `tool_start`, `token`, `tool_result`, `init`, `complete`, `status` |
+| One-shot (`runOneShot`) | theme switcher, factory-assemble, riff | `dispatchStreamEvent` | `tool_detail`, `generation_stage`, `preview_reload`, `preview_reload_failed` |
+
+Direction D's staged-preview events (`generation_stage` / `preview_reload` / `reference_preview`) are emitted by the bridge's stream parser, gated by `turnMode === 'generate'`, so they fire on the real editor generate flow. If you add generate-UX events in the future, emit them from the bridge, not from `runOneShot`.
+
+Before claiming a generate-flow feature works end-to-end: verify in the browser DevTools Console that the expected event types show up in `[WS-IN]` logs. Unit tests of `runOneShot` / `dispatchStreamEvent` do NOT exercise this path.
+
 ## Non-Obvious Files
 
 | File | Why it matters |
@@ -128,6 +148,10 @@ Then `npm run test:e2e:server` and open `http://test-app.local:3000`.
 | `scripts/lib/auth-constants.js` | Hardcoded OIDC authority and client ID (shared Pocket ID instance) |
 | `scripts/lib/env-utils.js` | Shared env utilities and config |
 | `scripts/lib/paths.js` | Centralized path resolution for all plugin paths |
+| `scripts/server/ws.ts` | WebSocket router — `case 'generate':` / `case 'chat':` / `case 'theme':` dispatch. The actual generate flow lives here, not in `handlers/generate.ts`. |
+| `scripts/server/claude-bridge.ts` | Persistent stream-json bridge (`createBridge`) — used for all multi-turn flows. Holds per-turn state via `setTurnMode`. Emits Direction D staged-preview events. |
+| `scripts/server/event-translator.ts` | Translates raw stream-json into UI events for the persistent bridge (`tool_start`, etc.). Separate from `dispatchStreamEvent` which belongs to `runOneShot`. |
+| `scripts/server/handlers/generate.ts` | **Unused in production.** `handleGenerate` exists but has no call sites; the real generate flow is in `ws.ts`. Don't edit this file expecting changes to affect generation. |
 | `skills/launch/LAUNCH-REFERENCE.md` | Launch dependency graph, timing, skip modes |
 | `skills/launch/prompts/builder.md` | Builder agent prompt template with {placeholder} markers |
 | `scripts/deploy-cloudflare.js` (asset discovery) | Auto-discovers app-level `assets/` directory and includes files in deploy payload |


### PR DESCRIPTION
## Summary

PR #73 fixed a real architectural gotcha that should never have taken as long as it did to spot. The editor's generate flow does NOT go through \`scripts/server/handlers/generate.ts:handleGenerate\` — that handler has zero call sites. The real flow is in \`ws.ts\` at \`case 'generate':\`, using the persistent bridge so brainstorm Q&A and the actual write can happen in one conversation.

CLAUDE.md didn't say this. A grep for \`handleGenerate\` / \`runOneShot\` / \`persistent bridge\` / \`ws.ts\` returned zero hits in the doc. This PR fixes that.

## What's added

1. **New "Generate Flow Routing" section** explaining:
   - \`handleGenerate\` is dead code; the real flow is \`ws.ts:case 'generate':\`
   - Why the persistent bridge is used (multi-turn brainstorm → generate continuity)
   - The two parallel stream-event translators and which one emits which UI event names
   - Where Direction D staged-preview events fire and why
   - **The manual verification rule:** unit tests of \`runOneShot\` / \`dispatchStreamEvent\` do NOT exercise the editor path — confirm via DevTools \`[WS-IN]\` logs before claiming a generate-flow feature works end-to-end
2. **Agent Quick Reference row** pointing future work at the new section before anyone edits the dead handler
3. **Non-Obvious Files entries** for \`ws.ts\`, \`claude-bridge.ts\`, \`event-translator.ts\`, and \`generate.ts\` (flagged as unused)

## Test plan

- [x] Docs-only change — no code. No test regressions possible.