### PR TITLE
docs: annotate Direction D plan/design with post-#73 routing reality

### DIFF
--- a/docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md
+++ b/docs/plans/2026-04-23-direction-d-multi-turn-generation-design.md
@@ -6,6 +6,30 @@
 
 ---
 
+> ## Status update — post-PR [#73](https://github.com/popmechanic/VibesOS/pull/73) / [#75](https://github.com/popmechanic/VibesOS/pull/75)
+>
+> This document describes a design where the staged-preview events
+> (`generation_stage`, `preview_reload`, `reference_preview`) are emitted from
+> `scripts/server/handlers/generate.ts::handleGenerate` via `runOneShot` /
+> `dispatchStreamEvent`. **That is not where they live in production.**
+>
+> After [#73](https://github.com/popmechanic/VibesOS/pull/73), the editor
+> generate flow runs through the **persistent bridge**
+> (`scripts/server/claude-bridge.ts::createBridge`), dispatched from
+> `scripts/server/ws.ts` at `case 'generate':`. The bridge emits the staged
+> preview events via `translateStreamEvent`, gated by
+> `turnMode === 'generate'`. `handleGenerate` was removed in
+> [#75](https://github.com/popmechanic/VibesOS/pull/75); only
+> `assembleAppFrame` survives in `handlers/generate.ts`, used by the
+> `/app-frame` route.
+>
+> The rest of this document — the two-step prompt structure, the event
+> protocol, the turn-sequencing rationale — is still accurate. Only the
+> implementation surface moved. See `CLAUDE.md` "Generate Flow Routing"
+> for the current routing note.
+
+---
+
 ## Summary
 
 Vibes OS app generation currently asks Claude to produce a complete React app in a single `Write` tool call. For complex apps (4,000+ lines of JSX/CSS with Canvas, SVG, animations), this reliably exceeds per-turn `max_tokens` limits. Users experience this as the generation hanging or producing a broken file.

--- a/docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md
+++ b/docs/plans/2026-04-23-direction-d-multi-turn-generation-plan.md
@@ -12,6 +12,34 @@
 
 ---
 
+> ## Status update — post-PR [#73](https://github.com/popmechanic/VibesOS/pull/73) / [#75](https://github.com/popmechanic/VibesOS/pull/75)
+>
+> This plan targets `scripts/server/handlers/generate.ts::handleGenerate` as
+> the site where staged-preview events are emitted and where `runOneShot`
+> is tuned. **That surface is gone in production.**
+>
+> After [#73](https://github.com/popmechanic/VibesOS/pull/73), the editor
+> generate flow runs through the **persistent bridge**
+> (`scripts/server/claude-bridge.ts::createBridge`), dispatched from
+> `scripts/server/ws.ts` at `case 'generate':`. Staged-preview events are
+> emitted by `translateStreamEvent` (in `event-translator.ts`), gated by
+> `turnMode === 'generate'`. `handleGenerate` and the one-shot-specific
+> `generation-events.test.ts` references to the editor path have been
+> cleaned up in [#75](https://github.com/popmechanic/VibesOS/pull/75);
+> only `assembleAppFrame` remains in `handlers/generate.ts` for the
+> `/app-frame` route.
+>
+> When reading task-by-task file references below, substitute:
+> - `scripts/server/handlers/generate.ts` (for emit sites) → `scripts/server/claude-bridge.ts` + `scripts/server/ws.ts`
+> - `dispatchStreamEvent` → `translateStreamEvent` (bridge path) — `dispatchStreamEvent` still exists and still powers `runOneShot` (theme / factory / riff), just not the editor
+> - `handleGenerate` → `case 'generate':` in `ws.ts`
+>
+> The prompt structure, event names and payloads, validator logic, and
+> editor-side UI plumbing are all still accurate. The routing landmine
+> is documented in `CLAUDE.md` "Generate Flow Routing."
+
+---
+
 ## File Structure
 
 ### Modified files


### PR DESCRIPTION
## Summary

- Both Direction D docs targeted `handleGenerate` / `dispatchStreamEvent` as the emit site for staged-preview events. The feature actually landed in the **persistent bridge** via #73, and #75 deleted the dead `handleGenerate`.
- Adds a prominent \`Status update\` block at the top of each doc that: (a) points at the real code paths (`ws.ts` `case 'generate':`, `claude-bridge.ts::createBridge`, `event-translator.ts::translateStreamEvent`), and (b) notes which parts of the design remain accurate (prompt structure, event protocol, validator) vs. what moved.
- Preserves the original body verbatim so the design rationale stays readable in context — no attempt to retrofit the task-by-task plan.

Follow-up from #73 and companion to #75.

## Test plan

- [x] Render the two docs and confirm the status-update block appears before the first section
- [x] Cross-check the referenced files exist at the named paths (`CLAUDE.md` "Generate Flow Routing", `scripts/server/ws.ts`, `scripts/server/claude-bridge.ts`, `scripts/server/event-translator.ts`)