### PR TITLE
fix(strip-code): prevent over-match across unrelated destructures

### DIFF
--- a/scripts/__tests__/unit/strip-code.test.js
+++ b/scripts/__tests__/unit/strip-code.test.js
@@ -232,6 +232,20 @@ function App() {}`;
     expect(result).not.toContain('const { useState } = React');
     expect(result).toContain('function App');
   });
+
+  // Regression: a destructure earlier in the file must not glue onto the
+  // React destructure and swallow everything between them.
+  it('does not over-match across an unrelated earlier destructure', () => {
+    const code = `const { foo } = someObj;
+const middle = 1;
+const { useState } = React;
+const after = 2;`;
+    const result = stripReactDestructuring(code);
+    expect(result).toContain('const { foo } = someObj');
+    expect(result).toContain('const middle = 1');
+    expect(result).toContain('const after = 2');
+    expect(result).not.toContain('const { useState } = React');
+  });
 });
 
 describe('stripWindowDestructuring', () => {
@@ -318,6 +332,36 @@ function App() {}`;
     const result = stripWindowDestructuring(code);
     expect(result).not.toContain('const { useApp } = window');
     expect(result).toContain('function App');
+  });
+
+  // Regression: a destructure earlier in the file must not glue onto the
+  // window destructure and swallow everything between them.
+  it('does not over-match across an unrelated earlier destructure', () => {
+    const code = `const { foo } = someObj;
+const middle = 1;
+const { useApp } = window;
+const after = 2;`;
+    const result = stripWindowDestructuring(code);
+    expect(result).toContain('const { foo } = someObj');
+    expect(result).toContain('const middle = 1');
+    expect(result).toContain('const after = 2');
+    expect(result).not.toContain('const { useApp } = window');
+  });
+
+  it('does not over-match across an unrelated earlier destructure (multi-line hook list)', () => {
+    const code = `const { foo } = someObj;
+const middle = 1;
+const {
+  useApp,
+  useRowIds,
+} = window;
+const after = 2;`;
+    const result = stripWindowDestructuring(code);
+    expect(result).toContain('const { foo } = someObj');
+    expect(result).toContain('const middle = 1');
+    expect(result).toContain('const after = 2');
+    expect(result).not.toContain('useApp');
+    expect(result).not.toContain('useRowIds');
   });
 });
 

--- a/scripts/lib/strip-code.js
+++ b/scripts/lib/strip-code.js
@@ -57,11 +57,11 @@ export function stripConstants(code, constants) {
  * @returns {string} Code with React destructuring removed
  */
 export function stripReactDestructuring(code) {
-  return code
-    // Multi-line first (greedy): const {\n  useState,\n} = React;
-    .replace(/^const\s+\{[\s\S]*?\}\s*=\s*React\s*;?\s*$/gm, '')
-    // Single-line: const { useState, useEffect } = React;
-    .replace(/^const\s+\{[^}]*\}\s*=\s*React\s*;?\s*$/gm, '');
+  // [^}] (not [\s\S]) so the match can span newlines inside the braces
+  // but cannot leap past an unrelated `}` on a preceding line. Without
+  // that guard, a destructure earlier in the file would glue onto this
+  // one and delete everything between them.
+  return code.replace(/^const\s+\{[^}]*\}\s*=\s*React\s*;?\s*$/gm, '');
 }
 
 /**
@@ -71,12 +71,11 @@ export function stripReactDestructuring(code) {
  * @returns {string} Code with window destructuring removed
  */
 export function stripWindowDestructuring(code) {
+  // See stripReactDestructuring for the [^}] vs [\s\S] rationale.
   return code
-    // Multi-line first (greedy): const {\n  useApp,\n} = window;
-    .replace(/^const\s+\{[\s\S]*?\}\s*=\s*window\s*;?\s*$/gm, '')
-    // Single-line: const { useApp } = window;
+    // const { useApp } = window;  (single- or multi-line identifier list)
     .replace(/^const\s+\{[^}]*\}\s*=\s*window\s*;?\s*$/gm, '')
-    // Conditional: const { useApp } = React.useMemo ? window : {};
+    // Conditional form from older templates: const { useApp } = React.useMemo ? window : {};
     .replace(/^const\s+\{[^}]*\}\s*=\s*React\.useMemo\s*\?\s*window\s*:\s*\{\}\s*;?\s*$/gm, '');
 }
 


### PR DESCRIPTION
## Summary

Flagged by the session's codebase audit as a silent data-loss bug. The multi-line variants of \`stripReactDestructuring\` and \`stripWindowDestructuring\` used \`[\\s\\S]*?\` inside the braces, which spans newlines and can leap across an unrelated earlier destructure all the way to the real \`} = React;\` / \`} = window;\` — swallowing every line in between.

**Reproduced locally:** input

\`\`\`js
const { foo } = someObj;
const x = 1;
const { useApp } = window;
const after = 2;
\`\`\`

became

\`\`\`js

const after = 2;
\`\`\`

after \`stripForTemplate\` — everything from line 1 through line 3 was stripped.

## The fix

Replace \`[\\s\\S]*?\` with \`[^}]*?\` in both functions. That still spans newlines inside the braces (so genuine multi-line hook lists keep working) but cannot cross an intermediate \`}\`, so an earlier destructure can no longer glue onto the target. Under \`[^}]\` the single-line and multi-line regexes become functionally identical, so both functions collapse to a single \`replace\` per target.

No behavior change for any input the existing tests cover.

## Test plan

- [x] Added regression test for the over-match case (single-line and multi-line hook list) in both \`stripReactDestructuring\` and \`stripWindowDestructuring\`
- [x] \`cd scripts && npm run test:unit\` — 733/733 passing
- [ ] Spot-check a recent app.jsx from \`~/.vibes/apps/\` — run \`stripForTemplate\` over it and diff output vs. current behavior to confirm no unintended stripping on real code