### PR TITLE
fix: four audit issues — factory AI proxy, deploy assets, unhandled editor events

### DIFF
--- a/scripts/assemble-factory.js
+++ b/scripts/assemble-factory.js
@@ -238,7 +238,7 @@ output = populateConnectConfig(output, envVars, true);
 output = output.split('__VITE_OIDC_AUTHORITY__').join(OIDC_AUTHORITY);
 output = output.split('__VITE_OIDC_CLIENT_ID__').join(OIDC_CLIENT_ID);
 output = output.split('__VITE_DEPLOY_API_URL__').join(DEPLOY_API_URL);
-output = output.split('__VITE_AI_PROXY_URL__').join(AI_PROXY_URL);
+output = output.split('__AI_PROXY_URL__').join(AI_PROXY_URL);
 
 // Known safe patterns that aren't config placeholders
 // __PURE__ is a tree-shaking comment used by bundlers

--- a/scripts/deploy-cloudflare.js
+++ b/scripts/deploy-cloudflare.js
@@ -11,7 +11,7 @@
 
 import { readFileSync, existsSync, unlinkSync } from "fs";
 import { resolve, dirname, join } from "path";
-import { buildPlatformFiles, addAppAssets, separateBySize } from './lib/deploy-files.js';
+import { buildPlatformFiles, addAppAssets, separateBySize, uploadR2Assets } from './lib/deploy-files.js';
 import { validateName, getApp, setApp } from './lib/registry.js';
 import { getAccessToken } from './lib/cli-auth.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL } from './lib/auth-constants.js';
@@ -141,31 +141,9 @@ async function main() {
     clientId: OIDC_CLIENT_ID,
   });
 
-  // Separate large files for R2 upload
+  // Separate large files for R2 upload, then deploy only the embedded files
   const { embed, r2: r2Files } = separateBySize(files);
-  if (Object.keys(r2Files).length > 0) {
-    console.log(`Uploading ${Object.keys(r2Files).length} large asset(s) to R2...`);
-    try {
-      const r2Resp = await fetch(`${DEPLOY_API_URL}/apps/${name}/assets`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${tokens.accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ files: r2Files }),
-      });
-      if (r2Resp.ok) {
-        console.log('R2 assets uploaded successfully');
-      } else {
-        const errText = await r2Resp.text();
-        console.warn(`R2 upload warning: ${errText}`);
-      }
-    } catch (e) {
-      console.warn(`R2 upload warning: ${e.message}`);
-    }
-  }
-
-  // Deploy with only embedded files (small files stay in worker script)
+  await uploadR2Assets(DEPLOY_API_URL, name, r2Files, tokens.accessToken);
   const result = await deployViaAPI(name, embed, tokens.accessToken, { aiKey });
 
   const deployedUrl = result.url || `https://${name}.vibesos.com`;

--- a/scripts/lib/deploy-files.js
+++ b/scripts/lib/deploy-files.js
@@ -90,6 +90,48 @@ export function addAppAssets(assetsDir, files) {
 }
 
 /**
+ * Upload large files to R2 via the Deploy API. Warnings on failure —
+ * deploy itself proceeds with just the embedded files, so a flaky R2
+ * upload doesn't block the deploy (the worker will 404 on those assets
+ * until the next deploy, which the caller can see by inspecting the
+ * returned resolved value).
+ *
+ * @param {string} apiUrl - Deploy API base URL
+ * @param {string} appName - Target app name
+ * @param {Record<string, string>} r2Files - Files to upload (may be empty)
+ * @param {string} accessToken - OIDC access token
+ * @param {(msg: string) => void} [log] - Optional logger (defaults to console.log / console.warn)
+ * @returns {Promise<boolean>} true if upload succeeded (or was empty), false if it warned
+ */
+export async function uploadR2Assets(apiUrl, appName, r2Files, accessToken, log) {
+  const logInfo = log || ((m) => console.log(m));
+  const logWarn = log || ((m) => console.warn(m));
+  const count = Object.keys(r2Files).length;
+  if (count === 0) return true;
+  logInfo(`Uploading ${count} large asset(s) to R2...`);
+  try {
+    const resp = await fetch(`${apiUrl}/apps/${appName}/assets`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ files: r2Files }),
+    });
+    if (resp.ok) {
+      logInfo('R2 assets uploaded successfully');
+      return true;
+    }
+    const errText = await resp.text();
+    logWarn(`R2 upload warning: ${errText}`);
+    return false;
+  } catch (e) {
+    logWarn(`R2 upload warning: ${e.message}`);
+    return false;
+  }
+}
+
+/**
  * Separate files into embedded (small) and R2 (large) based on size threshold.
  * index.html is always embedded regardless of size.
  * @param {Record<string, string>} files - Files map

--- a/scripts/lib/factory-assembly-validation.js
+++ b/scripts/lib/factory-assembly-validation.js
@@ -52,7 +52,6 @@ export const SAFE_PLACEHOLDER_PATTERNS = [
   '__VIBES_APP_CODE__',
   '__ADMIN_CODE__',
   '__VIBES_REGISTRY_URL__',
-  '__VITE_AI_PROXY_URL__',
   '__VIBES_JOINED__',
   '__VIBES_CONSOLE_LOG__',
   '__FACTORY_MODE__',

--- a/scripts/server/handlers/deploy.ts
+++ b/scripts/server/handlers/deploy.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, statSync } from 'fs';
 import { join } from 'path';
-import { buildPlatformFiles } from '../../lib/deploy-files.js';
+import { buildPlatformFiles, addAppAssets, separateBySize, uploadR2Assets } from '../../lib/deploy-files.js';
 import { getAccessToken } from '../../lib/cli-auth.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL } from '../../lib/auth-constants.js';
 import { provisionInviteLink } from '../../lib/provision-invite-link.js';
@@ -139,11 +139,21 @@ export async function handleDeploy(ctx: ServerContext, onEvent: EventCallback, t
 
   onEvent({ type: 'progress', progress: 30, stage: 'Deploying...', elapsed: getElapsed() });
 
-  // Build the files map for the Deploy API
+  // Build the files map for the Deploy API — must mirror the CLI
+  // (scripts/deploy-cloudflare.js) so editor deploys include app-level
+  // assets. Without addAppAssets the app's /assets directory is silently
+  // dropped and images/fonts 404 after deploy.
   const files: Record<string, string> = {
     'index.html': readFileSync(indexHtmlPath, 'utf8'),
     ...buildPlatformFiles(ctx.projectRoot),
   };
+  if (ctx.projectDir) {
+    addAppAssets(join(ctx.projectDir, 'assets'), files);
+  }
+
+  // Large assets go to R2 first; only embedded files are sent to /deploy.
+  const { embed, r2: r2Files } = separateBySize(files);
+  await uploadR2Assets(DEPLOY_API_URL, appName, r2Files, token);
 
   // Deploy via the Deploy API
   let deployUrl = '';
@@ -160,7 +170,7 @@ export async function handleDeploy(ctx: ServerContext, onEvent: EventCallback, t
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
       },
-      body: JSON.stringify({ name: appName, files, public: !isPrivate }),
+      body: JSON.stringify({ name: appName, files: embed, public: !isPrivate }),
     });
 
     clearInterval(progressInterval);

--- a/skills/vibes/templates/editor.html
+++ b/skills/vibes/templates/editor.html
@@ -4415,6 +4415,15 @@ window.escapeHtml = function(str) {
           updatePreviewOverlay(null, label);
           if (msg.name === 'Write') AsciiAnimation.start();
         }
+      } else if (msg.type === 'tool_detail') {
+        // Granular tool info (emitted after tool_start with a file path
+        // or input summary). Upgrade the thinking-stage label from the
+        // generic "Running Edit..." to "Edit: app.jsx" so the user sees
+        // what Claude is actually touching.
+        if (msg.input_summary) {
+          const label = (TOOL_LABELS[msg.name] || msg.name) + ': ' + msg.input_summary;
+          setThinking(true, null, label);
+        }
       } else if (msg.type === 'tool_result') {
         // Tool completed — update tool block with result
         updateToolResult(msg.name, msg.content, msg.is_error);
@@ -4519,6 +4528,12 @@ window.escapeHtml = function(str) {
           document.getElementById('generateBtn').disabled = false;
         }
         addMessage('system', 'Request cancelled.');
+      } else if (msg.type === 'theme_validation_failed') {
+        // Theme applied, but the creative pass modified app logic and was
+        // reverted to a safe version (colors/fonts only). Surface the
+        // message so the user knows a partial revert happened — without
+        // it the UI would look like a successful theme switch.
+        addMessage('error', msg.message || 'Theme validation failed; applied safe version.');
       } else if (msg.type === 'theme_selected') {
         // Server tells us which theme was selected (including auto-selection)
         currentThemeId = msg.themeId;


### PR DESCRIPTION
Bundle of four small fixes from the session's codebase audit. Each is independently small but they're thematically "user-visible bugs with mechanical fixes." Related: #77 (strip-code over-match — the higher-blast-radius fix kept separate for clean revert).

## Summary

1. **Factory apps: \`__AI_PROXY_URL__\` was never substituted.** [\`assemble-factory.js:241\`](scripts/assemble-factory.js) substituted \`__VITE_AI_PROXY_URL__\`, but [\`skills/factory/templates/unified.html\`](skills/factory/templates/unified.html) only has \`__AI_PROXY_URL__\` (no \`VITE_\` prefix). The unsubstituted placeholder was allow-listed in [\`factory-assembly-validation.js\`](scripts/lib/factory-assembly-validation.js), hiding the bug. Factory-deployed apps shipped with \`aiProxyUrl: \"__AI_PROXY_URL__\"\` literal — any non-factory-mode \`useAI()\` call failed silently. Fix: substitute the correct name, remove the stale safe-list entry.

2. **Editor deploys silently dropped app \`assets/\`.** [\`handlers/deploy.ts:143\`](scripts/server/handlers/deploy.ts) built the files map with only \`index.html\` + \`buildPlatformFiles\` (platform-level favicons/auth cards). The CLI path in [\`deploy-cloudflare.js:131\`](scripts/deploy-cloudflare.js) additionally calls \`addAppAssets\` + \`separateBySize\`. Result: apps with an \`assets/\` directory deployed from the editor lost all their images/fonts. Extracted \`uploadR2Assets()\` into [\`deploy-files.js\`](scripts/lib/deploy-files.js) so the R2 overflow path is shared, and wired both deploy paths to the same helpers. The two paths now behave identically.

3. **Editor never handled \`tool_detail\`.** [\`claude-bridge.ts:695\`](scripts/server/claude-bridge.ts) emits \`{ type: 'tool_detail', name, input_summary, elapsed }\` but [\`editor.html\`](skills/vibes/templates/editor.html) had no branch for it, so tool labels stayed at the generic \"Running Edit...\" instead of upgrading to \"Edit: app.jsx\". Added a handler that refines the thinking-stage label when \`input_summary\` is present.

4. **Editor never handled \`theme_validation_failed\`.** [\`handlers/theme.ts:147\`](scripts/server/handlers/theme.ts) emits this event when the creative pass modifies app logic and is reverted to a safe (colors/fonts only) version. The editor had no handler, so a partial revert looked like a clean success. Surface it via \`addMessage('error', ...)\`.

## Test plan

- [x] \`cd scripts && npm test\` — 762/762 passing
- [ ] Assemble a factory app and confirm the deployed HTML has a real \`aiProxyUrl\` (not the \`__AI_PROXY_URL__\` literal)
- [ ] Deploy an app with \`assets/logo.png\` from the editor and confirm the image resolves at \`/assets/logo.png\` on the deployed worker
- [ ] Run a chat turn in the editor and verify tool labels upgrade from \"Running Edit...\" → \"Edit: app.jsx\" in the thinking-stage text
- [ ] Trigger a theme with a creative pass that would fail validation (any theme against a complex app) and verify the revert message appears in chat