### PR TITLE
fix(theme): include typography marker in 2-step prompt + bail on cancel

### DIFF
--- a/scripts/server/handlers/theme.ts
+++ b/scripts/server/handlers/theme.ts
@@ -124,8 +124,13 @@ async function handleThemeSwitchMultiPass(ctx, onEvent, themeId, themeName, them
   // Use skipChat in onEvent — the wsAdapter will check event.skipChat
   const claudeResult = await runOneShot(prompt, { lockType: 'theme', skipChat: true, maxTurns: 5, model, cwd: resolveProjectDir(ctx, appName), tools: 'Read,Edit' }, onEvent, ctx.projectRoot);
 
+  // Cancellation: runOneShot returns null when the user cancels. In that
+  // case Claude never ran, so the guardrail below would see unchanged
+  // code, fall through the else branch, and make the cancel look like a
+  // successful theme switch. Bail out — runOneShot has already emitted
+  // the `cancelled` event upstream.
   if (claudeResult === null) {
-    onEvent({ type: 'app_updated' });
+    return;
   }
 
   // === Post-edit validation (Layer 2 guardrail) ===

--- a/scripts/server/prompt-builders.ts
+++ b/scripts/server/prompt-builders.ts
@@ -106,7 +106,7 @@ Build this app in two separate tool calls, in order. Each step has a specific pu
 STEP 1 — Write app.jsx: the visible skeleton.
 Produce a file that compiles and renders the app's basic shape — even without data or interactions. Include:
 - The exact __VIBES_THEMES__ + useVibesTheme code from above (unchanged)
-- A <style> tag with :root tokens and the four marker sections (/* @theme:tokens */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS
+- A <style> tag with :root tokens and the five marker sections (/* @theme:tokens */, /* @theme:typography */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS. Any @import font URLs belong inside @theme:typography — not at the top of the style tag.
 - A functioning component tree with visible elements: header with the app title, main content area, whatever structural regions fit this app (sidebar/nav/footer as needed). Components render placeholder/empty states but the layout is real.
 - Basic React hooks for local UI state (useState). NO TinyBase hooks yet. NO event handlers yet.
 - export default App


### PR DESCRIPTION
Two small theme-correctness fixes from the session's codebase audit.

## Summary

1. **[\`prompt-builders.ts:109\`](scripts/server/prompt-builders.ts:109)** — \`TWO_STEP_INSTRUCTIONS\` said "the four marker sections" and listed only tokens/surfaces/motion/decoration. There are actually **five** — see [\`theme-sections.js\`](scripts/lib/theme-sections.js):11 \`SECTION_NAMES = ['tokens', 'typography', 'surfaces', 'motion', 'decoration']\`. Because the prompt never told Claude about \`@theme:typography\`, generated apps land font \`@import\` URLs outside any marker, and the theme switcher's typography pass can't replace them cleanly. Adds the fifth marker and an explicit note that \`@import\` URLs must live inside it (matching [\`ai-instructions.ts:48\`](scripts/server/ai-instructions.ts:48)).

2. **[\`handlers/theme.ts:127-129\`](scripts/server/handlers/theme.ts:127)** — \`handleThemeSwitchMultiPass\` treated a cancelled run as success. \`runOneShot\` returns \`null\` on cancel; the handler emitted \`app_updated\`, then fell through to the post-edit guardrail. The guardrail saw unchanged code (Claude never ran), took the \`else\` branch at line 150, and quietly sanitized. User saw "app updated" after cancelling. Bail early on \`null\`; the \`cancelled\` event is already emitted upstream by \`runOneShot\`.

## Test plan

- [x] \`cd scripts && npm run test:unit\` — 733/733 passing
- [ ] Start editor, trigger theme switch, cancel mid-Pass-2. Confirm: no \"app updated\" notice, no ghost iframe reload.
- [ ] Generate a new app with the 2-step prompt. Confirm: generated app.jsx has all five \`@theme:*\` markers, \`@import\` (if any) is inside \`@theme:typography\`.