### PR TITLE
cleanup: rename legacy bridge file + remove duplicates and dead routes

### DIFF
--- a/scripts/server/bun-subprocess.ts
+++ b/scripts/server/bun-subprocess.ts
@@ -1,9 +1,9 @@
 /**
- * Legacy helpers extracted from claude-bridge.ts.
+ * Bun subprocess helpers — runs bun CLI scripts (assemble, deploy) as
+ * short-lived child processes and returns their captured stdout/stderr.
  *
- * Contains `runBunScript` (subprocess spawning for deploy/assemble)
- * and bun binary resolution. These are unchanged — kept here so
- * the main claude-bridge module can focus on the persistent bridge.
+ * Kept separate from `claude-bridge.ts` so that module can focus on the
+ * persistent stream-json bridge; this one has no Claude-specific logic.
  */
 
 import { existsSync } from 'fs';

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -934,9 +934,12 @@ export async function runOneShot(
     runState.resultText = (runState.resultText || '') + '\n\n*[Output was truncated at the token limit — the app was written but some follow-up content may be missing.]*';
   }
 
-  // Post-process
-  if (runState.hasEdited) {
-    sanitizeAppJsx(projectRoot);
+  // Post-process. `sanitizeAppJsx` joins its argument with 'app.jsx', so
+  // it needs the app directory (cwd), not the plugin root. Without cwd
+  // there's no file to sanitize — skip rather than silently no-op on
+  // `<plugin-root>/app.jsx`.
+  if (runState.hasEdited && opts.cwd) {
+    sanitizeAppJsx(opts.cwd);
   }
 
   let appJsxValid: boolean | undefined = undefined;
@@ -965,6 +968,3 @@ export async function runOneShot(
   return runState.resultText || null;
 }
 
-// --- Re-exports from legacy module ---
-
-export { runBunScript } from './claude-bridge-legacy.ts';

--- a/scripts/server/handlers/deploy.ts
+++ b/scripts/server/handlers/deploy.ts
@@ -13,7 +13,7 @@ import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL } from '../../lib/auth-c
 import { provisionInviteLink } from '../../lib/provision-invite-link.js';
 import { getApp, setApp } from '../../lib/registry.js';
 import { writeVibesJson } from '../../lib/vibes-json.js';
-import { runBunScript } from '../claude-bridge.ts';
+import { runBunScript } from '../bun-subprocess.ts';
 import type { EventCallback } from '../claude-bridge.ts';
 import type { ServerContext } from '../config.ts';
 import { resolveProjectDir } from '../app-context.js';

--- a/scripts/server/router.ts
+++ b/scripts/server/router.ts
@@ -919,7 +919,7 @@ export function createRouter(ctx: ServerContext) {
     }
 
     // Bundle files
-    if (url.pathname === '/oidc-bridge.js' || url.pathname === '/fireproof-oidc-bridge.js' || url.pathname === '/vibes-ai.js') {
+    if (url.pathname === '/oidc-bridge.js' || url.pathname === '/vibes-ai.js') {
       const bundlePath = join(ctx.projectRoot, 'bundles', url.pathname.slice(1));
       const file = Bun.file(bundlePath);
       if (await file.exists()) {

--- a/scripts/server/ws.ts
+++ b/scripts/server/ws.ts
@@ -23,6 +23,7 @@ import { createBridge, cancelCurrent, type PersistentBridge, type EventCallback 
 import { buildChatPrompt, buildGeneratePrompt, buildBrainstormPrompt } from './prompt-builders.ts';
 import { loadHistory, appendMessage, clearHistory } from './chat-history.ts';
 import { sanitizeAppJsx } from './post-process.ts';
+import { validateAppJsx } from '../lib/validate-app-jsx.ts';
 import { handleThemeSwitch, handlePaletteTheme } from './handlers/theme.ts';
 import { handleDeploy } from './handlers/deploy.ts';
 import { handleSaveTheme } from './handlers/create-theme.ts';
@@ -181,18 +182,6 @@ function snapshotAppJsxMtime(appDir: string): void {
  * off mid-token during a provider incident. Cheap, zero-dep, runs in a
  * few ms for a typical app.
  */
-function validateAppJsx(appDir: string): { ok: true } | { ok: false; error: string } {
-  const appPath = join(appDir, 'app.jsx');
-  try {
-    const source = readFileSync(appPath, 'utf-8');
-    const transpiler = new Bun.Transpiler({ loader: 'jsx' });
-    transpiler.transformSync(source);
-    return { ok: true };
-  } catch (err: any) {
-    return { ok: false, error: String(err?.message || err) };
-  }
-}
-
 /**
  * Check if app.jsx was modified since last snapshot. If so, run post-processing
  * and reassembly, then broadcast app_updated.
@@ -209,7 +198,7 @@ function checkAndReassemble(ctx: ServerContext, appDir: string): void {
       // Syntax-check the generated code before we let it propagate to
       // index.html and the preview frame's Babel transformer. Catches
       // truncated / malformed output from upstream model incidents.
-      const syntax = validateAppJsx(appDir);
+      const syntax = validateAppJsx(join(appDir, 'app.jsx'));
       if (!syntax.ok) {
         console.warn(`[WS] app.jsx has syntax errors, skipping assembly: ${syntax.error}`);
         broadcast({ type: 'app_invalid', error: syntax.error });


### PR DESCRIPTION
Four no-behavior-change cleanups from the session's audit.

## Summary

1. **Rename [\`claude-bridge-legacy.ts\`](scripts/server/bun-subprocess.ts) → [\`bun-subprocess.ts\`](scripts/server/bun-subprocess.ts).** The file is not legacy — it's the live subprocess-spawn helper used by [\`handlers/deploy.ts\`](scripts/server/handlers/deploy.ts) for assembly. The misleading name implied don't-touch when the code is actually on the hot path. Updated the one importer to pull directly from the renamed module; dropped the now-unnecessary re-export from [\`claude-bridge.ts\`](scripts/server/claude-bridge.ts).

2. **Remove the duplicate \`validateAppJsx\` in [\`ws.ts\`](scripts/server/ws.ts).** It was a thin wrapper around \`Bun.Transpiler\` duplicating [\`lib/validate-app-jsx.ts\`](scripts/lib/validate-app-jsx.ts) with a slightly different signature (\`appDir\` vs full path). Import the lib version and do the \`join\` at the call site.

3. **Fix \`sanitizeAppJsx(projectRoot)\` in \`runOneShot\`.** [\`post-process.ts:74\`](scripts/server/post-process.ts:74) joins its argument with \`'app.jsx'\`, so passing \`projectRoot\` (the plugin root) meant looking for \`<plugin-root>/app.jsx\` — which never exists, so \`existsSync\` returned false and the entire post-process step was a silent no-op in production. Use \`opts.cwd\` (the app directory) instead. **Note:** this is technically a behavior change — CSS-escape sanitization and redeclared-globals stripping on post-edit will now actually run for the one-shot path (theme switcher / factory / riff). The persistent-bridge path already calls \`sanitizeAppJsx\` correctly from elsewhere.

4. **Remove the Fireproof OIDC bridge route in [\`router.ts\`](scripts/server/router.ts).** Per [\`.claude/rules/sharing-architecture.md\`](.claude/rules/sharing-architecture.md) the pre-TinyBase sharing system is removed; the route handler still listed \`/fireproof-oidc-bridge.js\` alongside the live bundles, but nothing loads it.

## Intentionally scoped OUT

The audit flagged 5 Fireproof-era entries in [\`factory-assembly-validation.js\`](scripts/lib/factory-assembly-validation.js) \`SAFE_PLACEHOLDER_PATTERNS\` as stale. On verification, some are still populated at runtime (\`__VIBES_THEME_PRESETS__\` is in [\`source-templates/base/template.html:643\`](source-templates/base/template.html:643); \`__VIBES_LEDGER_MAP__\` is in \`skills/factory/templates/unified.html:3941\`). Pruning needs per-entry verification — punted to a follow-up.

## Test plan

- [x] \`cd scripts && npm test\` — 765/765 passing
- [ ] Run a theme switch in the editor and confirm post-edit sanitization runs (look for \`[PostProcess]\` log lines if the generated code had a CSS unicode escape)
- [ ] Confirm deploy still works via the editor (exercises the renamed \`runBunScript\` import path)