### PR TITLE
fix: robustness pass — registry, auth, deploy, shutdown, editor, env

### DIFF
--- a/scripts/deploy-cloudflare.js
+++ b/scripts/deploy-cloudflare.js
@@ -143,6 +143,26 @@ async function main() {
 
   // Separate large files for R2 upload, then deploy only the embedded files
   const { embed, r2: r2Files } = separateBySize(files);
+
+  // Cloudflare Workers have a 10 MB compressed script-size limit. Embedded
+  // files end up in the worker bundle, and base64 assets cost ~33% extra.
+  // Bail out BEFORE uploading with a clear error message instead of letting
+  // the Deploy API reject with raw Cloudflare error text.
+  const EMBED_BUDGET_BYTES = 7.5 * 1024 * 1024; // 7.5 MB pre-base64 ≈ 10 MB after encoding
+  let embedBytes = 0;
+  for (const v of Object.values(embed)) {
+    embedBytes += typeof v === 'string' && v.startsWith('base64:')
+      ? Buffer.from(v.slice(7), 'base64').length
+      : Buffer.byteLength(v, 'utf8');
+  }
+  if (embedBytes > EMBED_BUDGET_BYTES) {
+    const mb = (embedBytes / 1024 / 1024).toFixed(1);
+    throw new Error(
+      `Total embedded assets are ${mb} MB, which exceeds Cloudflare's worker script limit. ` +
+      `Move large files (>100 KB) to the assets/ directory — they'll upload to R2 instead.`
+    );
+  }
+
   await uploadR2Assets(DEPLOY_API_URL, name, r2Files, tokens.accessToken);
   const result = await deployViaAPI(name, embed, tokens.accessToken, { aiKey });
 

--- a/scripts/lib/cli-auth.js
+++ b/scripts/lib/cli-auth.js
@@ -263,6 +263,11 @@ function _startCallbackServer({ authority, clientId, authFile = DEFAULT_AUTH_FIL
         return;
       }
 
+      // We have a valid code — clear the 5-minute login timer so it
+      // can't fire mid-way through the token exchange and reject the
+      // promise with "Login timed out" after the user already succeeded.
+      clearTimeout(timer);
+
       // Exchange authorization code for tokens
       const tokenUrl = `${authority}/api/oidc/token`;
       const body = new URLSearchParams({

--- a/scripts/lib/env-utils.js
+++ b/scripts/lib/env-utils.js
@@ -61,9 +61,11 @@ export function populateConnectConfig(html, envVars, globalReplace = false) {
     }
   }
 
-  // TinyBase app config placeholders — use provided values or safe defaults
+  // TinyBase app config placeholders — use provided values or safe defaults.
+  // `in` check (not ||) so a caller can intentionally pass '' / 'false' / '0'
+  // without silently getting the default back.
   for (const [placeholder, defaultValue] of Object.entries(APP_CONFIG_PLACEHOLDERS)) {
-    const value = envVars[placeholder] || defaultValue;
+    const value = placeholder in envVars ? envVars[placeholder] : defaultValue;
     result = result.replaceAll(placeholder, value);
   }
 

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -33,7 +33,7 @@
  * }
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -77,13 +77,28 @@ export function loadRegistry() {
 /**
  * Save the deployment registry to disk.
  * Creates ~/.vibes/ directory if it doesn't exist.
+ *
+ * Writes atomically via a PID-suffixed temp file + rename so that two
+ * concurrent writers (e.g. CLI deploy racing with the editor's setApp)
+ * can't end up with a half-written / interleaved JSON file. This isn't
+ * full locking — the classic load→mutate→save lost-write race is still
+ * possible — but atomic rename is cheap and removes the worst case of a
+ * corrupt registry on disk.
  */
 export function saveRegistry(reg) {
   const dir = join(getVibesHome(), '.vibes');
   mkdirSync(dir, { recursive: true });
   const path = getRegistryPath();
-  writeFileSync(path, JSON.stringify(reg, null, 2), { mode: 0o600 });
-  // Also chmod in case the file already existed with broader permissions
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(reg, null, 2), { mode: 0o600 });
+  try {
+    renameSync(tmpPath, path);
+  } catch (e) {
+    // Clean up orphaned temp file if rename fails (e.g. cross-device).
+    try { unlinkSync(tmpPath); } catch {}
+    throw e;
+  }
+  // chmod in case the file already existed with broader permissions
   try { chmodSync(path, 0o600); } catch (e) { console.warn('chmod registry failed:', e.message); }
 }
 

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -97,12 +97,18 @@ export async function startServer(options?: StartServerOptions): Promise<StartSe
 
   // Only install signal handlers if not managed by caller
   if (!options?.managed) {
+    // On fatal errors, shut down the persistent Claude bridge and HTTP
+    // server before exiting — otherwise the child subprocess is orphaned
+    // and its PID leaks until the OS reaps it. `shutdownFn` is idempotent.
     process.on('uncaughtException', (err) => {
       console.error('[Process] Uncaught exception:', err);
-      process.exit(1);
+      shutdownFn();
+      setTimeout(() => process.exit(1), 1000);
     });
     process.on('unhandledRejection', (reason) => {
       console.error('[Process] Unhandled rejection:', reason);
+      shutdownFn();
+      setTimeout(() => process.exit(1), 1000);
     });
     process.on('SIGINT', () => { shutdownFn(); setTimeout(() => process.exit(0), 1000); });
     process.on('SIGTERM', () => { shutdownFn(); setTimeout(() => process.exit(0), 1000); });

--- a/skills/vibes/templates/editor.html
+++ b/skills/vibes/templates/editor.html
@@ -4304,7 +4304,12 @@ window.escapeHtml = function(str) {
       const frame = document.getElementById('previewFrame');
       if (!frame) return;
       if (overlayInError) overlayInError = false; // recovery: successful reload clears error
-      const name = currentProjectDir ? currentProjectDir.split('/').pop() : currentAppName;
+      // Strip trailing separators before splitting — `.split('/').pop()` on
+      // '/path/to/app/' returns '' and the cache-bust URL loses its app= param.
+      // Also handles backslash separators so Windows paths don't silently fail.
+      const name = currentProjectDir
+        ? currentProjectDir.replace(/[\\/]+$/, '').split(/[\\/]/).pop()
+        : currentAppName;
       const appParam = name ? 'app=' + encodeURIComponent(name) + '&' : '';
       frame.src = '/app-frame?' + appParam + 't=' + Date.now();
       // After a successful reload, restore the normal overlay copy for the current stage


### PR DESCRIPTION
Six small robustness fixes from the session's codebase audit. Each targets a latent footgun that would manifest as a confusing user-visible error.

## Summary

1. **[\`registry.js\`](scripts/lib/registry.js) — atomic write via temp+rename.** Two concurrent writers (CLI deploy racing editor \`setApp\`) could end up with a half-written / interleaved JSON file. Write to \`deployments.json.<pid>.tmp\` first and rename into place. Not full locking — the load→mutate→save lost-write race still exists and needs its own fix — but this removes the worst case of a corrupt file on disk.

2. **[\`cli-auth.js:264\`](scripts/lib/cli-auth.js:264) — clear login timer once code is received.** The 5-minute login timer could fire mid-way through the token exchange (after the browser callback returned, before the POST to \`/token\` completed). User would see \"Login timed out\" after already completing login in the browser. Clear the timer as soon as we have a valid code + state, before the exchange begins.

3. **[\`deploy-cloudflare.js:144\`](scripts/deploy-cloudflare.js:144) — budget check before deploy.** Cloudflare Workers have a 10 MB compressed script-size limit. Oversized deploys currently fail with raw Cloudflare error text, leaving the user guessing. Sum \`embed\` sizes after \`separateBySize\` and throw a clear \"move large files to \`assets/\`\" message before uploading.

4. **[\`server.ts:100\`](scripts/server.ts:100) — shutdown bridge on fatal errors.** \`uncaughtException\` called \`process.exit(1)\` without running \`shutdownFn\`, leaking the persistent Claude subprocess. \`unhandledRejection\` didn't exit at all, letting bad promises silently accumulate. Both now call \`shutdownFn\` and exit after a 1s grace period.

5. **[\`editor.html:4307\`](skills/vibes/templates/editor.html:4307) — strip trailing separators before split.** \`currentProjectDir.split('/').pop()\` returned \`''\` on trailing-slash paths, so the cache-bust URL lost its \`app=\` param and the preview loaded the wrong app. Also handle backslash separators for Windows paths.

6. **[\`env-utils.js:66\`](scripts/lib/env-utils.js:66) — \`in\` check instead of \`||\`.** \`envVars[placeholder] || default\` silently overrode legitimate falsy values (\`false\`, \`''\`, \`0\`). Nothing sets a falsy override today, but the next caller would hit a silent bug. Use \`in\` so explicit falsy values are respected.

## Dropped from scope on verification

The audit flagged [\`backup.js:62\`](scripts/lib/backup.js:62) \`pruneOldBackups\` regex as broken. I reproduced the regex in isolation — it compiles to \`/^index\\.\\d{8}-\\d{6}\\.bak\\.html$/\` and correctly matches real backup filenames like \`index.20260308-145103.bak.html\`. The reviewer's trace was wrong; no fix needed.

## Test plan

- [x] \`cd scripts && npm test\` — 765/765 passing
- [ ] Stress-test registry concurrency by running \`deploy-cloudflare.js\` while the editor is open and calling \`setApp\`; confirm \`deployments.json\` stays valid JSON
- [ ] Run a slow token exchange (e.g. throttle network) and confirm login still resolves instead of erroring with \"Login timed out\"
- [ ] Try to deploy an oversized app (embed > 7.5 MB); confirm the pre-check message fires instead of a Cloudflare error