### PR TITLE
Codebase audit: theme correctness, cleanup, robustness, bridge state-machine

### DIFF
--- a/scripts/deploy-cloudflare.js
+++ b/scripts/deploy-cloudflare.js
@@ -143,6 +143,26 @@ async function main() {
 
   // Separate large files for R2 upload, then deploy only the embedded files
   const { embed, r2: r2Files } = separateBySize(files);
+
+  // Cloudflare Workers have a 10 MB compressed script-size limit. Embedded
+  // files end up in the worker bundle, and base64 assets cost ~33% extra.
+  // Bail out BEFORE uploading with a clear error message instead of letting
+  // the Deploy API reject with raw Cloudflare error text.
+  const EMBED_BUDGET_BYTES = 7.5 * 1024 * 1024; // 7.5 MB pre-base64 ≈ 10 MB after encoding
+  let embedBytes = 0;
+  for (const v of Object.values(embed)) {
+    embedBytes += typeof v === 'string' && v.startsWith('base64:')
+      ? Buffer.from(v.slice(7), 'base64').length
+      : Buffer.byteLength(v, 'utf8');
+  }
+  if (embedBytes > EMBED_BUDGET_BYTES) {
+    const mb = (embedBytes / 1024 / 1024).toFixed(1);
+    throw new Error(
+      `Total embedded assets are ${mb} MB, which exceeds Cloudflare's worker script limit. ` +
+      `Move large files (>100 KB) to the assets/ directory — they'll upload to R2 instead.`
+    );
+  }
+
   await uploadR2Assets(DEPLOY_API_URL, name, r2Files, tokens.accessToken);
   const result = await deployViaAPI(name, embed, tokens.accessToken, { aiKey });
 

--- a/scripts/lib/cli-auth.js
+++ b/scripts/lib/cli-auth.js
@@ -263,6 +263,11 @@ function _startCallbackServer({ authority, clientId, authFile = DEFAULT_AUTH_FIL
         return;
       }
 
+      // We have a valid code — clear the 5-minute login timer so it
+      // can't fire mid-way through the token exchange and reject the
+      // promise with "Login timed out" after the user already succeeded.
+      clearTimeout(timer);
+
       // Exchange authorization code for tokens
       const tokenUrl = `${authority}/api/oidc/token`;
       const body = new URLSearchParams({

--- a/scripts/lib/env-utils.js
+++ b/scripts/lib/env-utils.js
@@ -61,9 +61,11 @@ export function populateConnectConfig(html, envVars, globalReplace = false) {
     }
   }
 
-  // TinyBase app config placeholders — use provided values or safe defaults
+  // TinyBase app config placeholders — use provided values or safe defaults.
+  // `in` check (not ||) so a caller can intentionally pass '' / 'false' / '0'
+  // without silently getting the default back.
   for (const [placeholder, defaultValue] of Object.entries(APP_CONFIG_PLACEHOLDERS)) {
-    const value = envVars[placeholder] || defaultValue;
+    const value = placeholder in envVars ? envVars[placeholder] : defaultValue;
     result = result.replaceAll(placeholder, value);
   }
 

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -33,7 +33,7 @@
  * }
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -77,13 +77,28 @@ export function loadRegistry() {
 /**
  * Save the deployment registry to disk.
  * Creates ~/.vibes/ directory if it doesn't exist.
+ *
+ * Writes atomically via a PID-suffixed temp file + rename so that two
+ * concurrent writers (e.g. CLI deploy racing with the editor's setApp)
+ * can't end up with a half-written / interleaved JSON file. This isn't
+ * full locking — the classic load→mutate→save lost-write race is still
+ * possible — but atomic rename is cheap and removes the worst case of a
+ * corrupt registry on disk.
  */
 export function saveRegistry(reg) {
   const dir = join(getVibesHome(), '.vibes');
   mkdirSync(dir, { recursive: true });
   const path = getRegistryPath();
-  writeFileSync(path, JSON.stringify(reg, null, 2), { mode: 0o600 });
-  // Also chmod in case the file already existed with broader permissions
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(reg, null, 2), { mode: 0o600 });
+  try {
+    renameSync(tmpPath, path);
+  } catch (e) {
+    // Clean up orphaned temp file if rename fails (e.g. cross-device).
+    try { unlinkSync(tmpPath); } catch {}
+    throw e;
+  }
+  // chmod in case the file already existed with broader permissions
   try { chmodSync(path, 0o600); } catch (e) { console.warn('chmod registry failed:', e.message); }
 }
 

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -97,12 +97,18 @@ export async function startServer(options?: StartServerOptions): Promise<StartSe
 
   // Only install signal handlers if not managed by caller
   if (!options?.managed) {
+    // On fatal errors, shut down the persistent Claude bridge and HTTP
+    // server before exiting — otherwise the child subprocess is orphaned
+    // and its PID leaks until the OS reaps it. `shutdownFn` is idempotent.
     process.on('uncaughtException', (err) => {
       console.error('[Process] Uncaught exception:', err);
-      process.exit(1);
+      shutdownFn();
+      setTimeout(() => process.exit(1), 1000);
     });
     process.on('unhandledRejection', (reason) => {
       console.error('[Process] Unhandled rejection:', reason);
+      shutdownFn();
+      setTimeout(() => process.exit(1), 1000);
     });
     process.on('SIGINT', () => { shutdownFn(); setTimeout(() => process.exit(0), 1000); });
     process.on('SIGTERM', () => { shutdownFn(); setTimeout(() => process.exit(0), 1000); });

--- a/scripts/server/bun-subprocess.ts
+++ b/scripts/server/bun-subprocess.ts
@@ -1,9 +1,9 @@
 /**
- * Legacy helpers extracted from claude-bridge.ts.
+ * Bun subprocess helpers — runs bun CLI scripts (assemble, deploy) as
+ * short-lived child processes and returns their captured stdout/stderr.
  *
- * Contains `runBunScript` (subprocess spawning for deploy/assemble)
- * and bun binary resolution. These are unchanged — kept here so
- * the main claude-bridge module can focus on the persistent bridge.
+ * Kept separate from `claude-bridge.ts` so that module can focus on the
+ * persistent stream-json bridge; this one has no Claude-specific logic.
  */
 
 import { existsSync } from 'fs';

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -11,7 +11,7 @@
 import { basename } from 'path';
 import { createStreamParser } from '../lib/stream-parser.js';
 import { buildPersistentArgs, resolveClaudeBin, cleanEnv } from '../lib/claude-subprocess.js';
-import { translateStreamEvent } from './event-translator.ts';
+import { createStreamTranslator } from './event-translator.ts';
 import { validateAppJsx } from '../lib/validate-app-jsx.ts';
 
 // --- Types ---
@@ -302,6 +302,9 @@ export function createBridge(appDir: string, onEvent: EventCallback, pluginRoot?
   let seq = 0;
   const eventLog = new RingBuffer<SequencedEvent>(RING_BUFFER_MAX);
   const turn: BridgeTurnState = createBridgeTurnState();
+  // Per-bridge stream translator — owns its own tool_input progress state
+  // so it doesn't leak between turns or across concurrent tool_use calls.
+  const translate = createStreamTranslator();
 
   function transition(action: BridgeAction): boolean {
     const next = nextState(state, action);
@@ -373,8 +376,10 @@ export function createBridge(appDir: string, onEvent: EventCallback, pluginRoot?
       // Staged-preview events (only fire during generate turns)
       dispatchBridgeEvent(rawEvent, turn, emitEvent);
 
-      // Translate raw stream-json event into UI-facing messages
-      const translated = translateStreamEvent(rawEvent);
+      // Translate raw stream-json event into UI-facing messages.
+      // Each bridge instance uses its own translator so per-turn progress
+      // state doesn't leak between turns.
+      const translated = translate(rawEvent);
       for (const msg of translated) {
         emitEvent(msg);
       }
@@ -474,10 +479,15 @@ export function createBridge(appDir: string, onEvent: EventCallback, pluginRoot?
       }
       // After SIGINT, the process should send a result event or exit.
       // If it exits, monitorExit transitions interrupted -> idle.
-      // Give it a moment, then force-transition to idle if still interrupted.
+      // If SIGINT was ignored, the old code only flipped state to idle —
+      // but proc was still alive and mid-turn, and the next sendMessage
+      // would write to its stdin and interleave with the previous turn.
+      // Now: also force-kill the process so the next sendMessage respawns
+      // cleanly via the `state === 'idle' && !proc` branch.
       setTimeout(() => {
         if (state === 'interrupted') {
-          console.log('[Bridge] Force-transitioning interrupted -> idle after timeout');
+          console.log('[Bridge] SIGINT did not land within 5s — force-killing process');
+          killProc();
           state = 'idle';
         }
       }, 5000);

--- a/scripts/server/claude-bridge.ts
+++ b/scripts/server/claude-bridge.ts
@@ -934,9 +934,12 @@ export async function runOneShot(
     runState.resultText = (runState.resultText || '') + '\n\n*[Output was truncated at the token limit — the app was written but some follow-up content may be missing.]*';
   }
 
-  // Post-process
-  if (runState.hasEdited) {
-    sanitizeAppJsx(projectRoot);
+  // Post-process. `sanitizeAppJsx` joins its argument with 'app.jsx', so
+  // it needs the app directory (cwd), not the plugin root. Without cwd
+  // there's no file to sanitize — skip rather than silently no-op on
+  // `<plugin-root>/app.jsx`.
+  if (runState.hasEdited && opts.cwd) {
+    sanitizeAppJsx(opts.cwd);
   }
 
   let appJsxValid: boolean | undefined = undefined;
@@ -965,6 +968,3 @@ export async function runOneShot(
   return runState.resultText || null;
 }
 
-// --- Re-exports from legacy module ---
-
-export { runBunScript } from './claude-bridge-legacy.ts';

--- a/scripts/server/event-translator.ts
+++ b/scripts/server/event-translator.ts
@@ -12,15 +12,15 @@
  *   complete    — run finished successfully
  *   error       — run flagged as failed or fatal error
  *   status      — misc state: rate_limited, context_compacted, retrying
+ *
+ * Per-turn state (tool_input progress tracking) is captured in a closure
+ * via `createStreamTranslator()` so each bridge instance gets its own
+ * state. The default `translateStreamEvent` export is a singleton kept
+ * for tests and existing call sites that don't need isolation.
  */
 
 const MAX_TOOL_RESULT_SIZE = 10 * 1024; // 10KB cap for UI delivery
 const PROGRESS_INTERVAL = 1024; // Emit progress every ~1KB of tool input
-
-// Accumulated tool input bytes — lets the UI show a progress bar during long Write calls
-let toolInputBytes = 0;
-let lastProgressEmit = 0;
-let currentToolName = '';
 
 const DROPPED_TYPES = new Set([
   'hook_started',
@@ -31,96 +31,118 @@ const DROPPED_TYPES = new Set([
   'task_progress',
 ]);
 
-export function translateStreamEvent(event: any): object[] {
-  if (DROPPED_TYPES.has(event.type)) return [];
+export type StreamTranslator = (event: any) => object[];
 
-  if (event.type === 'system') {
-    if (event.subtype === 'init') {
-      return [{ type: 'init', model: event.model, tools: event.tools, session_id: event.session_id }];
-    }
-    if (event.subtype === 'compact_boundary') {
-      return [{ type: 'status', status: 'context_compacted' }];
-    }
-    if (event.subtype === 'api_retry') {
-      return [{ type: 'status', status: 'retrying', attempt: event.attempt }];
-    }
-    return [];
-  }
+/**
+ * Create a stateful stream translator. Each bridge instance should
+ * call this once and reuse the returned function across its stream
+ * events, so per-turn progress tracking is isolated.
+ */
+export function createStreamTranslator(): StreamTranslator {
+  // Accumulated tool input bytes — lets the UI show a progress bar during long Write calls
+  let toolInputBytes = 0;
+  let lastProgressEmit = 0;
+  let currentToolName = '';
 
-  if (event.type === 'stream_event') {
-    const inner = event.event;
-    if (!inner) return [];
+  return function translateStreamEvent(event: any): object[] {
+    if (DROPPED_TYPES.has(event.type)) return [];
 
-    // Text delta — forward immediately
-    if (inner.type === 'content_block_delta' && inner.delta?.type === 'text_delta') {
-      return [{ type: 'token', text: inner.delta.text }];
-    }
-
-    // Tool use starting — reset progress tracking
-    if (inner.type === 'content_block_start' && inner.content_block?.type === 'tool_use') {
-      currentToolName = inner.content_block.name;
-      toolInputBytes = 0;
-      lastProgressEmit = 0;
-      return [{ type: 'tool_start', name: inner.content_block.name, id: inner.content_block.id }];
-    }
-
-    // Input JSON delta — accumulate bytes, emit periodic progress for Write/Edit tools
-    if (inner.type === 'content_block_delta' && inner.delta?.type === 'input_json_delta') {
-      toolInputBytes += (inner.delta.partial_json || '').length;
-      if (currentToolName === 'Write' || currentToolName === 'Edit') {
-        if (toolInputBytes - lastProgressEmit >= PROGRESS_INTERVAL) {
-          lastProgressEmit = toolInputBytes;
-          const kb = (toolInputBytes / 1024).toFixed(1);
-          // Asymptotic curve: grows visibly for typical apps (5-20KB), never hits 100%
-          const progress = Math.min(95, Math.round(100 * (1 - Math.exp(-toolInputBytes / 15000))));
-          return [{ type: 'status', progress, stage: `Writing code\u2026 ${kb} KB` }];
-        }
+    if (event.type === 'system') {
+      if (event.subtype === 'init') {
+        return [{ type: 'init', model: event.model, tools: event.tools, session_id: event.session_id }];
+      }
+      if (event.subtype === 'compact_boundary') {
+        return [{ type: 'status', status: 'context_compacted' }];
+      }
+      if (event.subtype === 'api_retry') {
+        return [{ type: 'status', status: 'retrying', attempt: event.attempt }];
       }
       return [];
     }
 
-    return [];
-  }
+    if (event.type === 'stream_event') {
+      const inner = event.event;
+      if (!inner) return [];
 
-  if (event.type === 'tool_result') {
-    // Reset progress tracking
-    currentToolName = '';
-    toolInputBytes = 0;
-    lastProgressEmit = 0;
-    const raw = typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '');
-    const truncated = raw.length > MAX_TOOL_RESULT_SIZE;
-    return [{
-      type: 'tool_result',
-      name: event.tool_name || '',
-      content: truncated ? raw.slice(0, MAX_TOOL_RESULT_SIZE) : raw,
-      is_error: !!event.is_error,
-      truncated,
-    }];
-  }
+      // Text delta — forward immediately
+      if (inner.type === 'content_block_delta' && inner.delta?.type === 'text_delta') {
+        return [{ type: 'token', text: inner.delta.text }];
+      }
 
-  if (event.type === 'result') {
-    if (event.is_error) {
-      return [{ type: 'error', message: event.result || 'Claude flagged the run as failed' }];
+      // Tool use starting — reset progress tracking
+      if (inner.type === 'content_block_start' && inner.content_block?.type === 'tool_use') {
+        currentToolName = inner.content_block.name;
+        toolInputBytes = 0;
+        lastProgressEmit = 0;
+        return [{ type: 'tool_start', name: inner.content_block.name, id: inner.content_block.id }];
+      }
+
+      // Input JSON delta — accumulate bytes, emit periodic progress for Write/Edit tools
+      if (inner.type === 'content_block_delta' && inner.delta?.type === 'input_json_delta') {
+        toolInputBytes += (inner.delta.partial_json || '').length;
+        if (currentToolName === 'Write' || currentToolName === 'Edit') {
+          if (toolInputBytes - lastProgressEmit >= PROGRESS_INTERVAL) {
+            lastProgressEmit = toolInputBytes;
+            const kb = (toolInputBytes / 1024).toFixed(1);
+            // Asymptotic curve: grows visibly for typical apps (5-20KB), never hits 100%
+            const progress = Math.min(95, Math.round(100 * (1 - Math.exp(-toolInputBytes / 15000))));
+            return [{ type: 'status', progress, stage: `Writing code\u2026 ${kb} KB` }];
+          }
+        }
+        return [];
+      }
+
+      return [];
     }
-    return [{
-      type: 'complete',
-      result: event.result || '',
-      usage: event.usage || null,
-      cost: event.total_cost_usd || null,
-      duration: event.duration_ms || null,
-    }];
-  }
 
-  if (event.type === 'rate_limit_event') {
-    return [{ type: 'status', status: 'rate_limited' }];
-  }
+    if (event.type === 'tool_result') {
+      // Reset progress tracking
+      currentToolName = '';
+      toolInputBytes = 0;
+      lastProgressEmit = 0;
+      const raw = typeof event.content === 'string' ? event.content : JSON.stringify(event.content || '');
+      const truncated = raw.length > MAX_TOOL_RESULT_SIZE;
+      return [{
+        type: 'tool_result',
+        name: event.tool_name || '',
+        content: truncated ? raw.slice(0, MAX_TOOL_RESULT_SIZE) : raw,
+        is_error: !!event.is_error,
+        truncated,
+      }];
+    }
 
-  // assistant messages with complete content blocks — drop when streaming is active
-  // (with --include-partial-messages, text arrives via stream_event text_delta AND
-  // again as complete assistant blocks, causing duplication)
-  if (event.type === 'assistant') {
+    if (event.type === 'result') {
+      if (event.is_error) {
+        return [{ type: 'error', message: event.result || 'Claude flagged the run as failed' }];
+      }
+      return [{
+        type: 'complete',
+        result: event.result || '',
+        usage: event.usage || null,
+        cost: event.total_cost_usd || null,
+        duration: event.duration_ms || null,
+      }];
+    }
+
+    if (event.type === 'rate_limit_event') {
+      return [{ type: 'status', status: 'rate_limited' }];
+    }
+
+    // assistant messages with complete content blocks — drop when streaming is active
+    // (with --include-partial-messages, text arrives via stream_event text_delta AND
+    // again as complete assistant blocks, causing duplication)
+    if (event.type === 'assistant') {
+      return [];
+    }
+
     return [];
-  }
-
-  return [];
+  };
 }
+
+/**
+ * Default singleton translator. Retained so tests and any caller that
+ * doesn't need per-instance state continue to work. Callers that care
+ * about isolation between turns (e.g. the persistent bridge, which runs
+ * many turns in its lifetime) should call `createStreamTranslator()`.
+ */
+export const translateStreamEvent: StreamTranslator = createStreamTranslator();

--- a/scripts/server/handlers/deploy.ts
+++ b/scripts/server/handlers/deploy.ts
@@ -13,7 +13,7 @@ import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL } from '../../lib/auth-c
 import { provisionInviteLink } from '../../lib/provision-invite-link.js';
 import { getApp, setApp } from '../../lib/registry.js';
 import { writeVibesJson } from '../../lib/vibes-json.js';
-import { runBunScript } from '../claude-bridge.ts';
+import { runBunScript } from '../bun-subprocess.ts';
 import type { EventCallback } from '../claude-bridge.ts';
 import type { ServerContext } from '../config.ts';
 import { resolveProjectDir } from '../app-context.js';

--- a/scripts/server/handlers/theme.ts
+++ b/scripts/server/handlers/theme.ts
@@ -124,8 +124,13 @@ async function handleThemeSwitchMultiPass(ctx, onEvent, themeId, themeName, them
   // Use skipChat in onEvent — the wsAdapter will check event.skipChat
   const claudeResult = await runOneShot(prompt, { lockType: 'theme', skipChat: true, maxTurns: 5, model, cwd: resolveProjectDir(ctx, appName), tools: 'Read,Edit' }, onEvent, ctx.projectRoot);
 
+  // Cancellation: runOneShot returns null when the user cancels. In that
+  // case Claude never ran, so the guardrail below would see unchanged
+  // code, fall through the else branch, and make the cancel look like a
+  // successful theme switch. Bail out — runOneShot has already emitted
+  // the `cancelled` event upstream.
   if (claudeResult === null) {
-    onEvent({ type: 'app_updated' });
+    return;
   }
 
   // === Post-edit validation (Layer 2 guardrail) ===

--- a/scripts/server/prompt-builders.ts
+++ b/scripts/server/prompt-builders.ts
@@ -106,7 +106,7 @@ Build this app in two separate tool calls, in order. Each step has a specific pu
 STEP 1 — Write app.jsx: the visible skeleton.
 Produce a file that compiles and renders the app's basic shape — even without data or interactions. Include:
 - The exact __VIBES_THEMES__ + useVibesTheme code from above (unchanged)
-- A <style> tag with :root tokens and the four marker sections (/* @theme:tokens */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS
+- A <style> tag with :root tokens and the five marker sections (/* @theme:tokens */, /* @theme:typography */, /* @theme:surfaces */, /* @theme:motion */, {/* @theme:decoration */}) present even when their contents are empty, plus base layout CSS. Any @import font URLs belong inside @theme:typography — not at the top of the style tag.
 - A functioning component tree with visible elements: header with the app title, main content area, whatever structural regions fit this app (sidebar/nav/footer as needed). Components render placeholder/empty states but the layout is real.
 - Basic React hooks for local UI state (useState). NO TinyBase hooks yet. NO event handlers yet.
 - export default App

--- a/scripts/server/router.ts
+++ b/scripts/server/router.ts
@@ -919,7 +919,7 @@ export function createRouter(ctx: ServerContext) {
     }
 
     // Bundle files
-    if (url.pathname === '/oidc-bridge.js' || url.pathname === '/fireproof-oidc-bridge.js' || url.pathname === '/vibes-ai.js') {
+    if (url.pathname === '/oidc-bridge.js' || url.pathname === '/vibes-ai.js') {
       const bundlePath = join(ctx.projectRoot, 'bundles', url.pathname.slice(1));
       const file = Bun.file(bundlePath);
       if (await file.exists()) {

--- a/scripts/server/ws.ts
+++ b/scripts/server/ws.ts
@@ -147,9 +147,18 @@ function getOrCreateBridge(ctx: ServerContext, appDir: string): PersistentBridge
       // On completion: final reassembly check + save full response to chat history
       if (event.type === 'complete') {
         checkAndReassemble(ctx, appDir);
-        const fullResponse = streamingTextBuffer || event.result || '';
-        if (fullResponse) {
-          appendMessage(appDir, { role: 'assistant', content: fullResponse });
+        // If the bridge is (or was just) interrupted, we already appended
+        // an "Interrupted" system message for this turn — don't then stack
+        // the partial assistant response on top. SIGINT can take a moment
+        // to land, so Claude may still emit a final `result` after cancel;
+        // drop it here so the chat history stays consistent with what the
+        // user actually saw.
+        const interrupted = bridge && bridge.state === 'interrupted';
+        if (!interrupted) {
+          const fullResponse = streamingTextBuffer || event.result || '';
+          if (fullResponse) {
+            appendMessage(appDir, { role: 'assistant', content: fullResponse });
+          }
         }
         streamingTextBuffer = '';
       }

--- a/scripts/server/ws.ts
+++ b/scripts/server/ws.ts
@@ -23,6 +23,7 @@ import { createBridge, cancelCurrent, type PersistentBridge, type EventCallback 
 import { buildChatPrompt, buildGeneratePrompt, buildBrainstormPrompt } from './prompt-builders.ts';
 import { loadHistory, appendMessage, clearHistory } from './chat-history.ts';
 import { sanitizeAppJsx } from './post-process.ts';
+import { validateAppJsx } from '../lib/validate-app-jsx.ts';
 import { handleThemeSwitch, handlePaletteTheme } from './handlers/theme.ts';
 import { handleDeploy } from './handlers/deploy.ts';
 import { handleSaveTheme } from './handlers/create-theme.ts';
@@ -181,18 +182,6 @@ function snapshotAppJsxMtime(appDir: string): void {
  * off mid-token during a provider incident. Cheap, zero-dep, runs in a
  * few ms for a typical app.
  */
-function validateAppJsx(appDir: string): { ok: true } | { ok: false; error: string } {
-  const appPath = join(appDir, 'app.jsx');
-  try {
-    const source = readFileSync(appPath, 'utf-8');
-    const transpiler = new Bun.Transpiler({ loader: 'jsx' });
-    transpiler.transformSync(source);
-    return { ok: true };
-  } catch (err: any) {
-    return { ok: false, error: String(err?.message || err) };
-  }
-}
-
 /**
  * Check if app.jsx was modified since last snapshot. If so, run post-processing
  * and reassembly, then broadcast app_updated.
@@ -209,7 +198,7 @@ function checkAndReassemble(ctx: ServerContext, appDir: string): void {
       // Syntax-check the generated code before we let it propagate to
       // index.html and the preview frame's Babel transformer. Catches
       // truncated / malformed output from upstream model incidents.
-      const syntax = validateAppJsx(appDir);
+      const syntax = validateAppJsx(join(appDir, 'app.jsx'));
       if (!syntax.ok) {
         console.warn(`[WS] app.jsx has syntax errors, skipping assembly: ${syntax.error}`);
         broadcast({ type: 'app_invalid', error: syntax.error });

--- a/skills/vibes/templates/editor.html
+++ b/skills/vibes/templates/editor.html
@@ -4304,7 +4304,12 @@ window.escapeHtml = function(str) {
       const frame = document.getElementById('previewFrame');
       if (!frame) return;
       if (overlayInError) overlayInError = false; // recovery: successful reload clears error
-      const name = currentProjectDir ? currentProjectDir.split('/').pop() : currentAppName;
+      // Strip trailing separators before splitting — `.split('/').pop()` on
+      // '/path/to/app/' returns '' and the cache-bust URL loses its app= param.
+      // Also handles backslash separators so Windows paths don't silently fail.
+      const name = currentProjectDir
+        ? currentProjectDir.replace(/[\\/]+$/, '').split(/[\\/]/).pop()
+        : currentAppName;
       const appParam = name ? 'app=' + encodeURIComponent(name) + '&' : '';
       frame.src = '/app-frame?' + appParam + 't=' + Date.now();
       // After a successful reload, restore the normal overlay copy for the current stage


### PR DESCRIPTION
Consolidates the four remaining open audit-driven PRs into one per your approval. Each commit preserves the original boundary so reviewing commit-by-commit works.

Supersedes and closes:
- #79 — fix(theme): typography marker + cancel bail
- #80 — cleanup: rename legacy bridge + remove duplicates and dead routes
- #81 — fix: robustness pass (registry, auth, deploy, shutdown, editor, env)
- #82 — fix(bridge): state-machine hardening

(#75, #76, #77, #78 landed separately earlier in the session and are already on main.)

## What's in the four commits

### 1. [\`ecb9081\`](../commit/ecb9081) — fix(theme): typography marker + cancel bail
- [\`prompt-builders.ts:109\`](scripts/server/prompt-builders.ts:109) — \`TWO_STEP_INSTRUCTIONS\` listed "four marker sections"; there are actually five. Generated apps were landing \`@import\` font URLs outside any marker, breaking the theme switcher's typography pass.
- [\`handlers/theme.ts:127\`](scripts/server/handlers/theme.ts:127) — \`handleThemeSwitchMultiPass\` emitted \`app_updated\` on cancel, making a cancelled theme switch look like a success. Bail early on \`null\` return from \`runOneShot\`.

### 2. [\`3ac0019\`](../commit/3ac0019) — cleanup: rename legacy bridge + remove duplicates and dead routes
- Renamed \`claude-bridge-legacy.ts\` → \`bun-subprocess.ts\`. The file is not legacy — it's the live subprocess-spawn helper used by deploy. Misleading name was a reading hazard.
- Removed the duplicate \`validateAppJsx\` in [\`ws.ts\`](scripts/server/ws.ts); imported from [\`lib/validate-app-jsx.ts\`](scripts/lib/validate-app-jsx.ts) and joined at the call site.
- Fixed \`sanitizeAppJsx(projectRoot)\` in \`runOneShot\` — it was passing the plugin root instead of the app dir, so post-process was a silent no-op in production. Uses \`opts.cwd\` now.
- Removed the Fireproof OIDC bridge route in [\`router.ts\`](scripts/server/router.ts) per \`.claude/rules/sharing-architecture.md\`.

### 3. [\`1f17704\`](../commit/1f17704) — fix: robustness pass (six small footguns)
- **registry.js** — atomic write via PID-suffixed temp file + rename, so concurrent CLI/editor writes can't produce a corrupt JSON file.
- **cli-auth.js** — clear the 5-minute login timer as soon as a valid code lands, so it can't fire mid-way through the token exchange and reject a successful login with "Login timed out".
- **deploy-cloudflare.js** — sum embedded-file sizes after \`separateBySize\` and bail with a clear message if we're over ~7.5 MB, instead of letting Cloudflare reject with raw error text.
- **server.ts** — \`uncaughtException\` and \`unhandledRejection\` now call \`shutdownFn\` before exit, so the persistent Claude subprocess doesn't orphan.
- **editor.html** — \`currentProjectDir.split('/').pop()\` returned \`''\` on trailing-slash paths, dropping the \`app=\` param from the cache-bust URL and loading the wrong app. Strip trailing separators and split on both \`/\` and \`\\\` for Windows paths.
- **env-utils.js** — \`envVars[placeholder] || default\` silently overrode legitimate falsy values; use \`in\` so \`false\` / \`''\` / \`0\` are respected.

### 4. [\`cfd923e\`](../commit/cfd923e) — fix(bridge): state-machine hardening
- **ws.ts cancel race** — gate the assistant-history append on \`bridge.state !== 'interrupted'\`. SIGINT takes a moment to land, so Claude could emit a final \`result\` after a cancel and stack a ghost reply on top of the "Interrupted" message.
- **claude-bridge.ts interrupt()** — call \`killProc()\` in the 5s SIGINT-fallback path so the subprocess actually dies. Previously the old code only flipped state to \`idle\`, leaving the proc alive; next \`sendMessage\` would write to a zombie stdin.
- **event-translator.ts** — extracted \`createStreamTranslator()\` factory so each bridge owns its own \`toolInputBytes\` / \`currentToolName\` state. Kept a default singleton export for back-compat with tests.

## Dropped from scope on verification (documented in prior PRs)

- \`backup.js\` \`pruneOldBackups\` regex — reviewer claimed it matches nothing; verified it actually compiles to \`/^index\\.\\d{8}-\\d{6}\\.bak\\.html$/\` and matches real backup files.
- \`factory-assembly-validation.js\` Fireproof-era safe-list entries — reviewer flagged five as stale; verified \`__VIBES_THEME_PRESETS__\` and \`__VIBES_LEDGER_MAP__\` are still populated at runtime.

## Test plan

- [x] \`cd scripts && npm test\` — 765/765 passing on the consolidated branch
- [ ] Cancel a generate mid-stream and confirm only "Interrupted" appears in chat history (no trailing ghost reply)
- [ ] Deploy from the editor with an \`assets/\` directory present and confirm it lands (exercised by #78 but belongs in the end-to-end check)
- [ ] Trigger a theme switch against a marker-bearing app; confirm the switcher's typography pass replaces \`@import\` URLs inside \`@theme:typography\`
- [ ] Confirm post-process (CSS escape sanitization, stripRedeclaredGlobals) actually runs after one-shot flows (theme / factory / riff) — was a silent no-op before the \`sanitizeAppJsx\` path fix