### PR TITLE
Refactor: assembly bg-patch + create-theme → runOneShot + safe-list rationale

### DIFF
--- a/scripts/__tests__/unit/assemble-validation.test.js
+++ b/scripts/__tests__/unit/assemble-validation.test.js
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { APP_PLACEHOLDER, injectCode, validateAssembly, checkForbiddenPatterns } from '../../lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode, validateAssembly, checkForbiddenPatterns, patchAppBackground } from '../../lib/assembly-utils.js';
 import {
   SAFE_PLACEHOLDER_PATTERNS,
   validateFactoryTemplate,
@@ -235,5 +235,46 @@ describe('validateFactoryAssembly (post-injection)', () => {
     const errors = validateFactoryAssembly(html, '');
     expect(errors).toContain('App code is empty');
     expect(errors).toContain('No App component found');
+  });
+});
+
+describe('patchAppBackground', () => {
+  const baseHtml = '<html><head><meta charset="utf-8"></head><body><div id="root"></div></body></html>';
+
+  it('extracts --color-background from :root and injects patches', () => {
+    const app = `:root { --color-background: oklch(15% 0 0); --color-text: white; }\nexport default function App() { return null; }`;
+    const out = patchAppBackground(baseHtml, app);
+    expect(out).toContain('oklch(15% 0 0)');
+    expect(out).toContain('body::before { background-color: oklch(15% 0 0) !important;');
+    expect(out).toContain('Cache-Control');
+  });
+
+  it('falls back to body background when :root has none', () => {
+    const app = `body { background: #ff0088; }\nexport default function App() { return null; }`;
+    const out = patchAppBackground(baseHtml, app);
+    expect(out).toContain('body::before { background-color: #ff0088');
+  });
+
+  it('rejects bg values containing CSS/HTML breakers', () => {
+    const app = `:root { --color-background: red; } body { background: red } --color-background: red; } <script>`;
+    // If extraction pulled the value "red }" (unclosed brace etc.), sanitizer rejects it
+    const appWithBad = `:root { --color-background: red{bad; }\nexport default function App() {}`;
+    const out = patchAppBackground(baseHtml, appWithBad);
+    expect(out).toContain('background-color: inherit');
+  });
+
+  it('uses "inherit" when no background is declared', () => {
+    const app = `export default function App() { return null; }`;
+    const out = patchAppBackground(baseHtml, app);
+    expect(out).toContain('background-color: inherit');
+  });
+
+  it('injects both head and body patches', () => {
+    const app = `:root { --color-background: blue; }\nfunction App() {}`;
+    const out = patchAppBackground(baseHtml, app);
+    // head patch
+    expect(out).toMatch(/<style>[\s\S]*body::before[\s\S]*<\/style>\s*\n<\/head>/);
+    // body patch — overlay rule
+    expect(out).toMatch(/div\[style\*="z-index: 10"\][\s\S]*<\/style>\s*\n<\/body>/);
   });
 });

--- a/scripts/assemble.js
+++ b/scripts/assemble.js
@@ -16,7 +16,7 @@ import { resolve } from 'path';
 import { TEMPLATES } from './lib/paths.js';
 import { createBackup } from './lib/backup.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from './lib/auth-constants.js';
-import { APP_PLACEHOLDER, AUTH_INJECT_MARKER, injectCode, validateAssembly, loadAndValidateTemplate, checkForbiddenPatterns, stripOidcImportBlock } from './lib/assembly-utils.js';
+import { APP_PLACEHOLDER, AUTH_INJECT_MARKER, injectCode, validateAssembly, loadAndValidateTemplate, checkForbiddenPatterns, stripOidcImportBlock, patchAppBackground } from './lib/assembly-utils.js';
 import { stripForTemplate } from './lib/strip-code.js';
 
 
@@ -118,6 +118,12 @@ async function main() {
 
     console.log('[eval-mode] Applied: shim injected, OIDC stripped, wsUrl=localhost:3334');
   }
+
+  // Patch background color + cache-control meta tags so the assembled
+  // HTML shows the app's bg through the template frame. Used to live in
+  // handlers/deploy.ts; moved here so editor/CLI/terminal assembly all
+  // get the same treatment.
+  output = patchAppBackground(output, appCode);
 
   // Validate output
   const validationErrors = validateAssembly(output, appCode);

--- a/scripts/lib/assembly-utils.js
+++ b/scripts/lib/assembly-utils.js
@@ -92,6 +92,60 @@ export function checkForbiddenPatterns(code) {
 }
 
 /**
+ * Extract the app's background color from its `:root` CSS custom property
+ * or `body` block, and inject two inline `<style>` blocks into the
+ * assembled HTML so the template frame and the floating overlay show the
+ * app's background instead of the template's default.
+ *
+ * Also injects cache-control meta tags so users always get the latest
+ * deploy rather than a CDN-cached copy.
+ *
+ * Previously ran at deploy time in handlers/deploy.ts — moved here so the
+ * same treatment applies to every assembly path (editor deploy, CLI
+ * deploy, terminal reassemble) without the deploy handler needing to
+ * re-read and re-write the HTML.
+ *
+ * @param {string} html - Assembled HTML output
+ * @param {string} appCode - The original app.jsx source (for color extraction)
+ * @returns {string} Patched HTML
+ */
+export function patchAppBackground(html, appCode) {
+  const rootMatch = appCode.match(/:root\s*\{([^}]+)\}/);
+  let bgColor = '';
+  if (rootMatch) {
+    const bgMatch = rootMatch[1].match(/--color-background\s*:\s*([^;]+)/);
+    if (bgMatch) bgColor = bgMatch[1].trim();
+  }
+  if (!bgColor) {
+    const bodyBgMatch = appCode.match(/body\s*\{[^}]*background\s*:\s*([^;]+)/);
+    if (bodyBgMatch) bgColor = bodyBgMatch[1].trim();
+  }
+
+  // Reject characters that could break out of CSS value or HTML context.
+  if (bgColor && /[;{}<>"']/.test(bgColor)) {
+    console.warn(`[assembly] Rejected suspicious bgColor value: ${bgColor.slice(0, 50)}`);
+    bgColor = '';
+  }
+  const bg = bgColor || 'inherit';
+
+  const headPatch = `<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <style>
+      #container { padding: 10px !important; }
+      body::before { background-color: ${bg} !important; }
+    </style>`;
+  html = html.replace('</head>', headPatch + '\n</head>');
+
+  const bodyPatch = `<style>
+      div[style*="z-index: 10"][style*="position: fixed"] { background: ${bg} !important; }
+    </style>`;
+  html = html.replace('</body>', bodyPatch + '\n</body>');
+
+  return html;
+}
+
+/**
  * Strip the OIDC dynamic import block from assembled HTML for eval-mode.
  * Removes the `if (hasOidc && !config.public) { try { ... } catch { ... } }` block
  * inside initApp() to prevent network requests to the OIDC authority.

--- a/scripts/lib/factory-assembly-validation.js
+++ b/scripts/lib/factory-assembly-validation.js
@@ -15,21 +15,31 @@
  * be allow-listed.
  */
 
-// Placeholders that are legitimately present AFTER assembly:
-// - __PURE__ / __esModule: Babel/Rollup build-tool globals.
-// - __APP_CONFIG__ / __VIBES_*__: runtime window-globals the tenant
-//   app sets itself (e.g., __VIBES_THEMES__ is set by app.jsx;
-//   __VIBES_OIDC_TOKEN__ is set by the OIDC bridge).
-// - __OIDC_LOAD_ERROR__: runtime error variable set by initApp() on
-//   OIDC load failure.
-// - __VIBES_APP_CODE__ / __ADMIN_CODE__: injection markers consumed
-//   by the assembler itself before validation — listed defensively.
-// - __FACTORY_MODE__ / __FACTORY_API_URL__: substituted at assembly
-//   time by the `replacements` map above — listed defensively in
-//   case substitution is missed.
-// - __CHECKOUT_URL__ / __BILLING_MODE__: substituted by
-//   deploy-api-factory at DEPLOY time, not assembly time, so they
-//   legitimately pass through the assembler untouched.
+// Placeholders that are legitimately present AFTER assembly. Each entry
+// below is accompanied by a note on WHY it's exempt, so future audits
+// don't try to prune items that are actually live.
+//
+// Categories:
+// - Build-tool globals (never substituted): __PURE__, __esModule
+// - Assembly-time substitutions (listed defensively in case a path misses
+//   the replace): __APP_NAME__, __APP_CONFIG__, __WS_URL__, __APP_PUBLIC__,
+//   __DEPLOY_API_URL__, __AI_PROXY_URL__, __FACTORY_MODE__, __FACTORY_API_URL__
+// - Deploy-time substitutions (filled in by deploy-api-factory, not by
+//   assemble-factory.js): __CHECKOUT_URL__, __BILLING_MODE__
+// - Runtime window globals the template/app sets itself: __VIBES_CONFIG__,
+//   __VIBES_OIDC_TOKEN__, __VIBES_SYNC_STATUS__, __VIBES_SYNC_ERROR__,
+//   __VIBES_THEMES__, __VIBES_THEME_PRESETS__, __VIBES_REGISTRY_URL__,
+//   __VIBES_CONSOLE_LOG__, __OIDC_LOAD_ERROR__
+// - Fireproof-era sharing globals still referenced by the factory template's
+//   pre-TinyBase sharing code path (skills/factory/templates/unified.html):
+//   __VIBES_SHARED_LEDGER__, __VIBES_LEDGER_MAP__, __VIBES_INVITE_ID__,
+//   __VIBES_JOINED__. These exist because the factory skill hasn't migrated
+//   to the TinyBase sync model yet. Per .claude/rules/sharing-architecture.md
+//   the pre-TinyBase sharing system is deprecated; removing these entries
+//   should follow (not precede) removing the factory template code that
+//   reads them.
+// - Injection markers consumed by the assembler before validation, but
+//   listed defensively: __VIBES_APP_CODE__, __ADMIN_CODE__
 export const SAFE_PLACEHOLDER_PATTERNS = [
   '__PURE__',
   '__esModule',
@@ -45,14 +55,14 @@ export const SAFE_PLACEHOLDER_PATTERNS = [
   '__VIBES_SYNC_STATUS__',
   '__VIBES_SYNC_ERROR__',
   '__VIBES_THEMES__',
-  '__VIBES_SHARED_LEDGER__',
-  '__VIBES_LEDGER_MAP__',
-  '__VIBES_INVITE_ID__',
-  '__VIBES_THEME_PRESETS__',
+  '__VIBES_SHARED_LEDGER__',   // factory: Fireproof-era, still referenced by unified.html
+  '__VIBES_LEDGER_MAP__',      // factory: Fireproof-era, still referenced by unified.html
+  '__VIBES_INVITE_ID__',       // factory: Fireproof-era, still referenced by unified.html
+  '__VIBES_THEME_PRESETS__',   // set by source-templates/base/template.html
   '__VIBES_APP_CODE__',
   '__ADMIN_CODE__',
   '__VIBES_REGISTRY_URL__',
-  '__VIBES_JOINED__',
+  '__VIBES_JOINED__',          // factory + riff template; read by bundles/oidc-bridge.js
   '__VIBES_CONSOLE_LOG__',
   '__FACTORY_MODE__',
   '__FACTORY_API_URL__',

--- a/scripts/server/handlers/create-theme.ts
+++ b/scripts/server/handlers/create-theme.ts
@@ -1,6 +1,8 @@
 /**
  * Save current app theme as a reusable catalog theme.
- * Uses one-shot Bun.spawn for the extraction subprocess.
+ * Delegates the Claude subprocess run to `runOneShot` so we don't maintain
+ * a third parallel stream-json loop alongside the persistent bridge and
+ * the theme switcher.
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -8,8 +10,7 @@ import { join } from 'path';
 import { reloadThemes } from '../config.ts';
 import type { ServerContext } from '../config.ts';
 import { resolveAppJsxPath } from '../app-context.js';
-import { buildClaudeArgs, cleanEnv, resolveClaudeBin } from '../../lib/claude-subprocess.js';
-import { createStreamParser } from '../../lib/stream-parser.js';
+import { runOneShot } from '../claude-bridge.ts';
 import type { EventCallback } from '../claude-bridge.ts';
 
 function slugify(text: string): string {
@@ -33,6 +34,7 @@ async function extractThemeFromAppJsx(
   themeId: string,
   themeName: string,
   model: string | undefined,
+  onEvent: EventCallback,
 ): Promise<string> {
   const themeDir = join(projectRoot, 'skills/vibes/themes');
   const archivePath = join(themeDir, 'archive.txt');
@@ -66,84 +68,37 @@ Tasks:
 
 Use oklch() for ALL color values.`;
 
-  const args = buildClaudeArgs({
-    outputFormat: 'stream-json',
-    maxTurns: 10,
-    tools: 'Edit,Read,Write',
-    model,
-    permissionMode: 'bypassPermissions',
-  });
+  console.log(`[SaveTheme] Running one-shot extraction for theme "${themeId}"...`);
 
-  console.log(`[SaveTheme] Spawning claude for theme "${themeId}"...`);
+  // Drop runOneShot's fine-grained progress/tool events — the caller drives
+  // its own wall-clock `saving_theme` status timer because those stream
+  // events don't map cleanly onto a single "extracting theme" UX stage.
+  // Forward errors so the user still sees meaningful failure reasons.
+  const filteredOnEvent: EventCallback = (event) => {
+    if (event.type === 'error') onEvent(event);
+  };
 
-  const proc = Bun.spawn({
-    cmd: [resolveClaudeBin(), ...args],
-    cwd: projectRoot,
-    env: cleanEnv(),
-    stdin: 'pipe',
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  const result = await runOneShot(
+    extractionPrompt,
+    {
+      lockType: 'save_theme',
+      skipChat: true,
+      maxTurns: 10,
+      tools: 'Edit,Read,Write',
+      model,
+      permissionMode: 'bypassPermissions',
+      cwd: projectRoot,
+    },
+    filteredOnEvent,
+    projectRoot,
+  );
 
-  proc.stdin.write(extractionPrompt);
-  proc.stdin.end();
-
-  let stderrBuffer = '';
-  let resultText = '';
-
-  // Read stderr
-  const stderrPromise = (async () => {
-    const reader = proc.stderr.getReader();
-    const decoder = new TextDecoder();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        stderrBuffer += decoder.decode(value, { stream: true });
-      }
-    } catch {}
-  })();
-
-  // Read stdout
-  const parse = createStreamParser((event: any) => {
-    if (event.type === 'assistant' && event.message?.content) {
-      for (const block of event.message.content) {
-        if (block.type === 'text' && block.text) resultText = block.text;
-        if (block.type === 'tool_use') console.log(`[SaveTheme] Tool: ${block.name || ''}`);
-      }
-    } else if (event.type === 'result') {
-      if (event.is_error) console.error(`[SaveTheme] Result is_error: ${event.result}`);
-      else resultText = event.result || resultText || 'Done.';
-    }
-  });
-
-  // Start timeout BEFORE reading stdout so it fires even if the read loop hangs
-  const EXTRACT_TIMEOUT = 240_000;
-  const timeoutId = setTimeout(() => {
-    console.error(`[SaveTheme] Timeout after ${EXTRACT_TIMEOUT / 1000}s — killing subprocess`);
-    proc.kill('SIGTERM');
-  }, EXTRACT_TIMEOUT);
-
-  const reader = proc.stdout.getReader();
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      parse(value);
-    }
-  } catch {}
-
-  const exitCode = await proc.exited;
-  clearTimeout(timeoutId);
-  await stderrPromise;
-
-  if (exitCode !== 0) {
-    console.error(`[SaveTheme] Failed (code ${exitCode}): ${stderrBuffer.slice(0, 300)}`);
-    throw new Error(`Theme save failed (exit code ${exitCode})`);
+  if (result === null) {
+    throw new Error('Theme save was cancelled');
   }
 
   console.log(`[SaveTheme] Theme "${themeId}" created successfully`);
-  return resultText;
+  return result;
 }
 
 /**
@@ -183,7 +138,7 @@ export async function handleSaveTheme(
     }, 2000);
 
     try {
-      await extractThemeFromAppJsx(ctx.projectRoot, appCode, themeId, themeName, model);
+      await extractThemeFromAppJsx(ctx.projectRoot, appCode, themeId, themeName, model, onEvent);
     } finally {
       clearInterval(progressInterval);
     }

--- a/scripts/server/handlers/deploy.ts
+++ b/scripts/server/handlers/deploy.ts
@@ -5,7 +5,7 @@
  * The CLI sends files and reads back the wsUrl from the response.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, statSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, copyFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { buildPlatformFiles, addAppAssets, separateBySize, uploadR2Assets } from '../../lib/deploy-files.js';
 import { getAccessToken } from '../../lib/cli-auth.js';
@@ -94,48 +94,9 @@ export async function handleDeploy(ctx: ServerContext, onEvent: EventCallback, t
     return;
   }
 
-  // Patch assembled HTML so the app's background shows through the template frame
-  try {
-    const appCode = readFileSync(appJsxPath, 'utf8');
-    let html = readFileSync(indexHtmlPath, 'utf8');
-
-    const rootMatch = appCode.match(/:root\s*\{([^}]+)\}/);
-    let bgColor = '';
-    if (rootMatch) {
-      const bgMatch = rootMatch[1].match(/--color-background\s*:\s*([^;]+)/);
-      if (bgMatch) bgColor = bgMatch[1].trim();
-    }
-    if (!bgColor) {
-      const bodyBgMatch = appCode.match(/body\s*\{[^}]*background\s*:\s*([^;]+)/);
-      if (bodyBgMatch) bgColor = bodyBgMatch[1].trim();
-    }
-
-    // Sanitize bgColor — reject characters that could break out of CSS value or HTML context
-    if (bgColor && /[;{}<>"']/.test(bgColor)) {
-      console.warn(`[Deploy] Rejected suspicious bgColor value: ${bgColor.slice(0, 50)}`);
-      bgColor = '';
-    }
-    const bg = bgColor || 'inherit';
-
-    const headPatch = `<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
-    <style>
-      #container { padding: 10px !important; }
-      body::before { background-color: ${bg} !important; }
-    </style>`;
-    html = html.replace('</head>', headPatch + '\n</head>');
-
-    const bodyPatch = `<style>
-      div[style*="z-index: 10"][style*="position: fixed"] { background: ${bg} !important; }
-    </style>`;
-    html = html.replace('</body>', bodyPatch + '\n</body>');
-
-    writeFileSync(indexHtmlPath, html);
-    console.log('[Deploy] Patched body::before background' + (bgColor ? `: ${bgColor}` : ''));
-  } catch (e: any) {
-    console.error('[Deploy] Patch failed:', e.message);
-  }
+  // Background color patch + cache-control meta tags are applied inside
+  // assemble.js (lib/assembly-utils.js::patchAppBackground) — by the time
+  // we read the assembled HTML below it's already patched.
 
   onEvent({ type: 'progress', progress: 30, stage: 'Deploying...', elapsed: getElapsed() });
 

--- a/scripts/server/handlers/generate.ts
+++ b/scripts/server/handlers/generate.ts
@@ -7,7 +7,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { stripForTemplate } from '../../lib/strip-code.js';
-import { APP_PLACEHOLDER, injectCode } from '../../lib/assembly-utils.js';
+import { APP_PLACEHOLDER, injectCode, patchAppBackground } from '../../lib/assembly-utils.js';
 import { populateConnectConfig } from '../../lib/env-utils.js';
 import { OIDC_AUTHORITY, OIDC_CLIENT_ID, DEPLOY_API_URL, AI_PROXY_URL } from '../../lib/auth-constants.js';
 import { TEMPLATES } from '../../lib/paths.js';
@@ -53,6 +53,10 @@ export function assembleAppFrame(ctx, appName?: string) {
   template = template.replaceAll('__OIDC_CLIENT_ID__', OIDC_CLIENT_ID);
   template = template.replaceAll('__DEPLOY_API_URL__', DEPLOY_API_URL);
   template = template.replaceAll('__AI_PROXY_URL__', AI_PROXY_URL);
+
+  // Patch bg color + cache-control so the preview iframe matches
+  // the deployed app. Same helper as assemble.js uses.
+  template = patchAppBackground(template, appCode);
 
   return template;
 }


### PR DESCRIPTION
Closes out the three items deferred from the codebase-audit work.

## Commits

### 1. [\`5af733e\`](../commit/5af733e) — docs(validation): annotate factory safe-list entries with rationale

The audit flagged five [\`SAFE_PLACEHOLDER_PATTERNS\`](scripts/lib/factory-assembly-validation.js) entries as stale Fireproof-era code. Verified each is still live:
- \`__VIBES_SHARED_LEDGER__\` / \`__VIBES_LEDGER_MAP__\` / \`__VIBES_INVITE_ID__\` — read/written by [\`skills/factory/templates/unified.html\`](skills/factory/templates/unified.html) (factory skill hasn't migrated off the pre-TinyBase sharing model yet).
- \`__VIBES_THEME_PRESETS__\` — set by [\`source-templates/base/template.html:643\`](source-templates/base/template.html:643).
- \`__VIBES_JOINED__\` — read by [\`bundles/oidc-bridge.js\`](bundles/oidc-bridge.js) and the riff template.

No entries pruned. Added per-entry comments so the next audit doesn't repeat this investigation.

### 2. [\`3f37208\`](../commit/3f37208) — refactor(create-theme): migrate to runOneShot

[\`handleSaveTheme\`](scripts/server/handlers/create-theme.ts) carried its own parallel stream-json subprocess loop — stream parser, stderr pump, timeout, exit-code handling, result-text extraction — all reimplemented inline. Replaced with a single \`runOneShot\` call (\`lockType: 'save_theme'\`). Kept the wall-clock \`progressInterval\` that drives \`saving_theme\` status events since those don't map cleanly onto per-tool stream events.

Net: ~45 lines deleted. New behavior: a theme save is now cancellable via the same operation-lock path as every other one-shot (previously you had to wait it out or kill the server).

### 3. [\`594dbb8\`](../commit/594dbb8) — refactor(assembly): move bg-color patch from deploy handler into assembly

[\`handlers/deploy.ts\`](scripts/server/handlers/deploy.ts) carried a 40-line block that ran at deploy time: regex out \`--color-background\` from app.jsx, inject two \`<style>\` blocks into the assembled HTML, write back to disk. Moved the logic to [\`lib/assembly-utils.js::patchAppBackground\`](scripts/lib/assembly-utils.js) and call it from:

- [\`scripts/assemble.js\`](scripts/assemble.js) — every assembly now gets the same treatment (CLI deploy, editor deploy, terminal reassemble)
- [\`handlers/generate.ts::assembleAppFrame\`](scripts/server/handlers/generate.ts) — the preview iframe now matches the deployed app's background

Deploy handler now just reads the already-patched HTML; no re-write step. Added 5 unit tests covering happy path, body-background fallback, sanitizer rejection, no-background-declared, and injection-point verification.

Minor behavior change: the preview iframe's frame now takes the app's background instead of defaulting to 'inherit'. The deployed HTML is byte-identical to before (same patch, same place, different producer).

## Test plan

- [x] \`cd scripts && npm test\` — 770/770 passing (previous baseline 765 + 5 new \`patchAppBackground\` tests)
- [ ] Editor: trigger \"Save current theme\" mid-run and cancel — confirm the subprocess dies (new behavior)
- [ ] Deploy an app from the CLI; inspect the rendered page source on the deployed worker and confirm the cache-control meta tags + body::before style are present
- [ ] Open the preview iframe while app.jsx has a non-default \`--color-background\`; confirm the iframe frame shows that color instead of the template default